### PR TITLE
Allow navigating to definition without split

### DIFF
--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -319,6 +319,8 @@ function! tsuquyomi#definition()
       " Same file
       call tsuquyomi#bufManager#pushNavDef(l:file, {'line': l:line, 'col': l:offset})
       call cursor(l:info.start.line, l:info.start.offset)
+    elseif g:tsuquyomi_definition_split == 0
+      execute 'edit +call\ cursor('.l:info.start.line.','.l:info.start.offset.') '.l:info.file
     else
       " If other file, split window
       execute 'split +call\ cursor('.l:info.start.line.','.l:info.start.offset.') '.l:info.file

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -198,6 +198,12 @@ g:tsuquyomi_tsserver_path	(default `''`)
 g:tsuquyomi_nodejs_path		(default 'node')
 		A path to Node.js.
 
+
+						g:tsuquyomi_definition_split
+g:tsuquyomi_definition_split	(default 1)
+		Whether to open a new split when navigating to definition in
+		another file. See :TsuquyomiDefinition.
+
 ------------------------------------------------------------------------------
 KEY MAPPINGS					*tsuquyomi-key-mappings*
 

--- a/plugin/tsuquyomi.vim
+++ b/plugin/tsuquyomi.vim
@@ -36,6 +36,8 @@ let g:tsuquyomi_waittime_after_open=
       \ get(g:, 'tsuquyomi_waittime_after_open', 0.01)
 let g:tsuquyomi_completion_chank_size = 
       \ get(g:, 'tsuquyomi_completion_chank_size', 15)
+let g:tsuquyomi_definition_split =
+      \ get(g:, 'tsuquyomi_definition_split', 1)
 " Global options defintion. }}}
 
 " augroup tsuquyomi_global_command_group


### PR DESCRIPTION
Adds `g:tsuquyomi_definition_split` variable.

When set to `0`, if the definition is in another file, it will navigate to it in the current buffer instead of opening a split.