### PR TITLE
Remove useless wait-time

### DIFF
--- a/autoload/tsuquyomi/tsClient.vim
+++ b/autoload/tsuquyomi/tsClient.vim
@@ -209,9 +209,7 @@ endfunction
 " This command does not return any response.
 function! tsuquyomi#tsClient#tsOpen(file)
   let l:args = {'file': a:file}
-  let l:res = tsuquyomi#tsClient#sendCommandOneWay('open', l:args)
-  call s:waitTss(g:tsuquyomi_waittime_after_open)
-  return l:res
+  call tsuquyomi#tsClient#sendCommandOneWay('open', l:args)
 endfunction
 
 " Send close command to TSServer.


### PR DESCRIPTION
tsuquyomi を入れた後，TypeScript のコードの読み込みに1秒以上余分にかかるようになってしまいました．
調べてみたところ，`tsuquyomi#open` が呼び出す `tsuquyomi#tsClient#tsOpen` がサーバからのレスポンスを（デフォルトで 100ms）待っているのが主な原因でした．

`tsOpen` はサーバからのレスポンスを戻り値として返すために wait-time を入れているようですが，`tsOpen` の戻り値は grep で調べた限りではどこでも使われていなかったので，`return` 文および wait する処理を単純に削除しました．

これによって TypeScript のソースコード（空ファイル）を開いたときの Vim の起動速度が下記のように改善しました．

- Before: __1356.274ms__
- After: __337.600ms__

（詳しい start-up time は [こちら](https://gist.github.com/rhysd/389979c514331632e740)）
### 環境
- Ubuntu
- Vim 7.4.728
