### PR TITLE
Reduce the number of calling vital#of()

### DIFF
--- a/autoload/tsuquyomi/bufManager.vim
+++ b/autoload/tsuquyomi/bufManager.vim
@@ -8,8 +8,6 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:V = vital#of('tsuquyomi')
-
 let s:buf_info_map = {}
 
 function! s:normalize(buf_name)

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -9,10 +9,7 @@ if !tsuquyomi#config#preconfig()
   finish
 endif
 
-let s:V = vital#of('tsuquyomi')
-let s:P = s:V.import('ProcessManager')
-
-if(!exists(g:tsuquyomi_is_available) && !s:P.is_available())
+if(!exists(g:tsuquyomi_is_available))
   let g:tsuquyomi_is_available = 0
   echom '[Tsuquyomi] Shougo/vimproc.vim is not installed. Please install it.'
   finish


### PR DESCRIPTION
- bufManager.vim 内にある `vital#of()` 呼び出しは使われていないようでしたので削除しました
- ftplugin/typescript.vim 内にある `vital#of()` は `ProcessManager.is_available()` のために呼ばれていますが，`ProcessManager.is_available()` はすでに `tsuquyomi#config#preconfig()` 内でチェック済みのため不要のようです．よって削除しました．

なお，`vital#of()` は結構重い処理で複数回呼ぶと環境によっては問題になったりするため，多くのプラグインでは一度 `vital#of()` を呼んだ時の結果を持っておいて使い回しているようです． [（例えば neocomplete）](https://github.com/Shougo/neocomplete.vim/blob/26bb5c8ff619366b948c757a18ff7a4d71fbcf14/autoload/neocomplete/util.vim#L31)
よろしければご検討ください．