### PR TITLE
Missing quote.

### DIFF
--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -9,7 +9,7 @@ if !tsuquyomi#config#preconfig()
   finish
 endif
 
-if(!exists(g:tsuquyomi_is_available))
+if(!exists("g:tsuquyomi_is_available"))
   let g:tsuquyomi_is_available = 0
   echom '[Tsuquyomi] Shougo/vimproc.vim is not installed. Please install it.'
   finish


### PR DESCRIPTION
クオートがない影響で、`let g:tsuquyomi_is_available = 0`を実行しているif文に必ず入ってしまい、うまく動作していませんでした。