### PR TITLE
Add g:tsuquyomi_completion_preview option

### DIFF
--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -301,7 +301,12 @@ function! tsuquyomi#complete(findstart, base)
     let length = strlen(a:base)
     if enable_menu
       call tsuquyomi#perfLogger#record('start_menu')
-      let [has_info, siginfo] = tsuquyomi#makeCompleteInfo(l:file, l:line, l:start)
+      if g:tsuquyomi_completion_preview
+        let [has_info, siginfo] = tsuquyomi#makeCompleteInfo(l:file, l:line, l:start)
+      else
+        let [has_info, siginfo] = [0, '']
+      endif
+
       let size = g:tsuquyomi_completion_chunk_size
       let j = 0
       while j * size < len(l:res_list)
@@ -314,6 +319,9 @@ function! tsuquyomi#complete(findstart, base)
                 \ || !g:tsuquyomi_completion_case_sensitive && info.name[0:length - 1] == a:base
                 \ || g:tsuquyomi_completion_case_sensitive && info.name[0:length - 1] ==# a:base
             let l:item = {'word': info.name, 'menu': info.kind }
+            if has_info
+                let l:item.info = siginfo
+            endif
             if !g:tsuquyomi_completion_detail
               call complete_add(l:item)
             else
@@ -329,9 +337,6 @@ function! tsuquyomi#complete(findstart, base)
           let idx = 0
           for menu in menus
             let items[idx].menu = menu
-            if has_info
-              let items[idx].info = siginfo
-            endif
             call complete_add(items[idx])
             let idx = idx + 1
           endfor

--- a/doc/tsuquyomi.jax
+++ b/doc/tsuquyomi.jax
@@ -280,6 +280,14 @@ g:tsuquyomi_completion_case_sensitive	(デフォルト値 0)
 		|tsuquyomi#complete|実行時に補完候補をcase-sensitiveに
 		探索するかどうか.
 
+					*g:tsuquyomi_completion_preview*
+g:tsuquyomi_completion_preview		(デフォルト値 0)
+		|tsuquyomi#complete|実行時にシグネチャの情報をプレビューに表示
+		するかどうか.
+		このオプションは|completeopt|に "menu"と"preview"が含まれるとき
+		にのみ意味を持つ.
+		NOTE: このオプションを1に設定した場合, 補完速度は少し遅くなる
+
 						*g:tsuquyomi_disable_default_mappings*
 g:tsuquyomi_disable_default_mappings	(デフォルト値 0)
 		デフォルトキーマッピングを適用するかどうか.

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -272,6 +272,13 @@ g:tsuquyomi_completion_case_sensitive	(default 0)
 		Whether to search completion case-sensitively when
 		|tsuquyomi#complete|.
 
+					*g:tsuquyomi_completion_preview*
+g:tsuquyomi_completion_preview		(default 0)
+		Whether to show sigunature in preview when |tsuquyomi#complete|.
+		This options makes sence when |completeopt| includes "menu"
+		and "preview".
+		NOTE: If it's set, completions gets a little slow.
+
 						*g:tsuquyomi_disable_default_mappings*
 g:tsuquyomi_disable_default_mappings	(default 0)
 		If set no keys are mapped.

--- a/plugin/tsuquyomi.vim
+++ b/plugin/tsuquyomi.vim
@@ -42,6 +42,8 @@ let g:tsuquyomi_completion_detail =
       \ get(g:, 'tsuquyomi_completion_detail', 0)
 let g:tsuquyomi_completion_case_sensitive = 
       \ get(g:, 'tsuquyomi_completion_case_sensitive', 0)
+let g:tsuquyomi_completion_preview = 
+      \ get(g:, 'tsuquyomi_completion_preview', 0)
 let g:tsuquyomi_definition_split =
       \ get(g:, 'tsuquyomi_definition_split', 0)
 let g:tsuquyomi_disable_quickfix =


### PR DESCRIPTION
When `g:tsuquyomi_completion_detail` is `0`, `tsuquyomi#makeCompleteInfo()` is called but its result is never used.
Removing it will make completion faster.

This PR also add `g:tsuquyomi_completion_preview` option.
This option allow to enable preview(signature help) independently of `g:tsuquyomi_completion_detail`.