### PR TITLE
Add option to ignore errors caused by missing modules

### DIFF
--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -495,6 +495,9 @@ function! tsuquyomi#createQuickFixListFromEvents(event_list)
   for event_item in a:event_list
     if has_key(event_item, 'type') && event_item.type ==# 'event' && (event_item.event ==# 'syntaxDiag' || event_item.event ==# 'semanticDiag')
       for diagnostic in event_item.body.diagnostics
+        if diagnostic.text =~ "Cannot find module" && g:tsuquyomi_ignore_missing_modules == 1
+          continue
+        endif
         let item = {}
         let item.filename = event_item.body.file
         let item.lnum = diagnostic.start.line

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -305,6 +305,12 @@ g:tsuquyomi_javascript_support	(default 0)
 		You can further configure tsserver's behavior using
 		tsconfig.json or jsconfig.json in your project.
 
+						*g:tsuquyomi_ignore_missing_modules*
+g:tsuquyomi_ignore_missing_modules (default 0)
+		If set, Tsuquyomi will ignore any error that starts with
+		"Cannot find module". Useful when you don't have type
+		definitions for all of your imports.
+
 ------------------------------------------------------------------------------
 KEY MAPPINGS					*tsuquyomi-key-mappings*
 

--- a/plugin/tsuquyomi.vim
+++ b/plugin/tsuquyomi.vim
@@ -54,6 +54,8 @@ let g:tsuquyomi_single_quote_import =
       \ get(g:, 'tsuquyomi_single_quote_import', 0)
 let g:tsuquyomi_javascript_support =
       \ get(g:, 'tsuquyomi_javascript_support', 0)
+let g:tsuquyomi_ignore_missing_modules =
+      \ get(g:, 'tsuquyomi_ignore_missing_modules', 0)
 " Global options defintion. }}}
 
 " augroup tsuquyomi_global_command_group


### PR DESCRIPTION
Adds an option to ignore errors that contain `Cannot find module`. This is very useful for me working in a codebase where we don't have typings for everything. This will result in missed actual errors, but better that that false positives in my opinion.

This is my first attempt at vimscript so let me know if I have missed anything or am breaking convention.

Ran tests locally and they still pass. Have not added tests for this functionality, but this works with and without the flag enabled for me.

**Todo** add info about the flag to the japanese docs