### PR TITLE
Show documentation in balloonexpr() and hint()

### DIFF
--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -588,6 +588,10 @@ function! tsuquyomi#balloonexpr()
   call s:flush()
   let res = tsuquyomi#tsClient#tsQuickinfo(fnamemodify(buffer_name(v:beval_bufnr),":p"), v:beval_lnum, v:beval_col)
   if has_key(res, 'displayString')
+    if (has_key(res, 'documentation') && res.documentation != '')
+      return join([res.documentation, res.displayString], "\n\n")
+    endif
+
     return res.displayString
   endif
 endfunction
@@ -596,6 +600,10 @@ function! tsuquyomi#hint()
   call s:flush()
   let res = tsuquyomi#tsClient#tsQuickinfo(expand('%:p'), line('.'), col('.'))
   if has_key(res, 'displayString')
+    if (has_key(res, 'documentation') && res.documentation != '')
+      return join([res.documentation, res.displayString], "\n\n")
+    endif
+
     return res.displayString
   else
     return '[Tsuquyomi] There is no hint at the cursor.'


### PR DESCRIPTION
`tsserver` offers the ability to show documentation when jsdoc annotation is given. This is helpful to get some context in how to use certain function. 

## Demo

![img](https://s3-us-west-1.amazonaws.com/adhawk-random-public/tsu-docs.png)