### PR TITLE
Import the shortest path with :TsuImport.

### DIFF
--- a/autoload/tsuquyomi/es6import.vim
+++ b/autoload/tsuquyomi/es6import.vim
@@ -217,12 +217,6 @@ function! s:findExportingFileForModule(module, current_module_file, module_direc
   return l:extracted_file_name
 endfunction
 
-function! s:substitute_typescript_extension(path)
-  let l:result = substitute(l:plop, '\.d\.ts$', '', '')
-  let l:result = substitute(l:plop, '\.ts$', '', '')
-  return l:result
-endfunction
-
 function! s:comp_alias(alias1, alias2)
   return a:alias2.spans[0].end.line - a:alias1.spans[0].end.line
 endfunction


### PR DESCRIPTION
This PR adds the possibility to get the shortest path instead of the complete one using the `TsuImport` command. 
It basically uses `vimgrep` under the hood and successively check if there is a path exporting the module on the way from the current file to the one containing the imported module. 

It starts from the imported module's directory, and walk back toward the current edited file. It stores the current 'shortened path' and reduce it if there is a match against the provided regular expression:

```
  execute 
        \"silent! noautocmd vimgrep /export\\s*\\({.*\\(\\s\\|,\\)"
        \. a:module 
        \."\\(\\s\\|,\\)*.*}\\|\\*\\)\\s\\+from\\s\\+\\(\\'\\|\\\"\\)\\.\\\/"
        \. substitute(a:current_module_file, '\/', '\\/', '') 
        \."[\\/]*\\(\\'\\|\\\"\\)[;]*/j "
        \. a:module_directory_path 
        \. "*.ts"

```
if no match is found, the path stored in 'shortened_path' is the one picked up along the way. 
The algorithm also loops in the current directory when a match in the module export is found, to try to see if there is another possible path reference. It's the case for instance for the OnInit hook module: It's initially referenced (according to TypeScript navto command) in `@angular/core/src/metadata/lifecycle_hooks.d.ts`. The module is first exported through the `@angular/core/src/metadata.d.ts`, which in turn is exported by the `core.d.ts` file in the same directory.

If an `index.d.ts `or `index.ts` is found along the way, the path to find will be modified to include the expression `[index]*[/]*`, meaning that it could be exported explicitly or through the directory. if such an expression is contained in the final shortest path, it's substituted from it. 

The algorithms handle 3 cases:
when the module comes from a package located in node_modules:
![import_node](https://cloud.githubusercontent.com/assets/8367233/20869139/600de8a4-ba6c-11e6-9a6a-cfdbba9b4c68.gif)

from a file located in a directory beyond the current's file path in the tree (relative path starting with `./`):
![import_forward](https://cloud.githubusercontent.com/assets/8367233/20869141/6698ef0c-ba6c-11e6-9904-1ac5d973f010.gif)

from a file located in a directory before the current's file path (relative path starting with `../`):
![import_back](https://cloud.githubusercontent.com/assets/8367233/20869146/7f62fc44-ba6c-11e6-8ed8-d0dbc2ecf831.gif)

Also, the `noautocmd` argument is used for `vimgrep` which gives a great speed boost to the search. In the end, there is no big difference in the execution time between the command with the shortest path algorithm and without.

To activate the feature, the `g:tsuquyomi_import_shortest_path` has to be set to 1 explicitly (it's set to 0 by default). 