### PR TITLE
Fix shortest path import variable type mismatch

### DIFF
--- a/autoload/tsuquyomi/es6import.vim
+++ b/autoload/tsuquyomi/es6import.vim
@@ -206,8 +206,8 @@ function! s:findExportingFileForModule(module, current_module_file, module_direc
   endif
   let l:raw_result = split(l:grep_result, ' ')[2]
   let l:raw_result = split(l:raw_result, ':')[0]
-  let l:raw_result = split(l:raw_result, '/')
-  let l:extracted_file_name = l:raw_result[len(l:raw_result) -1 ]
+  let l:raw_result_parts = split(l:raw_result, '/')
+  let l:extracted_file_name = l:raw_result_parts[len(l:raw_result_parts) -1 ]
   let l:extracted_file_name = substitute(l:extracted_file_name, '\.d\.ts$', '', '')
   let l:extracted_file_name = substitute(l:extracted_file_name, '\.ts$', '', '')
   return l:extracted_file_name


### PR DESCRIPTION
Enabling `let g:tsuquyomi_shortest_import_path = 1` lead to the following errors for me:

![2016-12-23_08-40-49](https://cloud.githubusercontent.com/assets/1691925/21448460/8f5c1ef4-c8eb-11e6-8066-b6abe50bfa8d.png)


The import it created looked like this:
![2016-12-23_08-27-29](https://cloud.githubusercontent.com/assets/1691925/21448377/a1fb75c4-c8ea-11e6-9cb0-eb89433a3775.png)
when it should've looked like `import { TagJson } from "../../api/json";`

This update fixes the type mismatch and allows to create proper imports.
