### PR TITLE
Option for import curly spacing

### DIFF
--- a/autoload/tsuquyomi/es6import.vim
+++ b/autoload/tsuquyomi/es6import.vim
@@ -391,10 +391,16 @@ function! tsuquyomi#es6import#complete()
 
   "Add import declaration
   if !len(l:same_path_import_list)
+	if g:tsuquyomi_import_curly_spacing == 0
+	  let l:curly_spacing = ''
+	else
+	  let l:curly_spacing = ' '
+	end
+
     if g:tsuquyomi_single_quote_import
-      let l:expression = "import { ".l:block.identifier." } from '".l:block.path."';"
+      let l:expression = "import {".l:curly_spacing.l:block.identifier.l:curly_spacing."} from '".l:block.path."';"
     else
-      let l:expression = 'import { '.l:block.identifier.' } from "'.l:block.path.'";'
+      let l:expression = 'import {'.l:curly_spacing.l:block.identifier.l:curly_spacing.'} from "'.l:block.path.'";'
     endif
     call append(l:module_end_line, l:expression)
   else

--- a/plugin/tsuquyomi.vim
+++ b/plugin/tsuquyomi.vim
@@ -52,6 +52,8 @@ let g:tsuquyomi_save_onrename =
       \ get(g:, 'tsuquyomi_save_onrename', 0)
 let g:tsuquyomi_single_quote_import =
       \ get(g:, 'tsuquyomi_single_quote_import', 0)
+let g:tsuquyomi_import_curly_spacing =
+      \ get(g:, 'tsuquyomi_import_curly_spacing', 1)
 let g:tsuquyomi_javascript_support =
       \ get(g:, 'tsuquyomi_javascript_support', 0)
 let g:tsuquyomi_ignore_missing_modules =


### PR DESCRIPTION
Hey guys! 👋

Our TS style-guide requires no spacing for the curly braces in import statements:
```ts
// GOOD
import {Iterable, List, Set} from "immutable";

// BAD - spaces inside curly brackets
import { Iterable, List, Set } from "immutable";
```

So I have added the `g:tsuquyomi_import_curly_spacing` option which can be:
* `1` — **default**, a single space inside curly brackets, or
* `0` — no spacing.

I’m wondering if this is a frequent enough need to be merged. 🤔 

What do you think? 🤓 