### PR TITLE
fix vimproc error when typescript is installed locally on Windows

### DIFF
--- a/autoload/tsuquyomi/config.vim
+++ b/autoload/tsuquyomi/config.vim
@@ -110,6 +110,7 @@ function! tsuquyomi#config#getVersion()
     return s:tss_version
   endif
   let l:cmd = substitute(tsuquyomi#config#tsscmd(), 'tsserver', 'tsc', '')
+  let l:cmd = substitute(l:cmd, "\\", "/", "g")
   let out = s:Process.system(l:cmd.' --version')
   let pattern = '\vVersion\s+(\d+)\.(\d+)\.(\d+)-?([^\.\n\s]*)'
   let matched = matchlist(out, pattern)


### PR DESCRIPTION
When typescript is installed locally to the project, tsuquyomi
attempts to invoke the command line:

    > node "%CD%\node_modules\typescript\bin\tsc" --version

when getting the typescript version. That `\n` in `\node_modules` gets
interpreted as a newline for some reason, and causes node to issue a
"module not found" error.

The quick fix is to replace all instances of \\ with / in the command
line, as nodejs on Windows will read them as path separators just fine.