### PR TITLE
Adding another member to an existing import: be aware of curly spacing setting

### DIFF
--- a/autoload/tsuquyomi/es6import.vim
+++ b/autoload/tsuquyomi/es6import.vim
@@ -389,14 +389,14 @@ function! tsuquyomi#es6import#complete()
   let l:new_line = l:new_line.l:line[l:identifier_info.end.offset: -1]
   call setline(l:identifier_info.start.line, l:new_line)
 
+  if g:tsuquyomi_import_curly_spacing == 0
+    let l:curly_spacing = ''
+  else
+    let l:curly_spacing = ' '
+  end
+
   "Add import declaration
   if !len(l:same_path_import_list)
-	if g:tsuquyomi_import_curly_spacing == 0
-	  let l:curly_spacing = ''
-	else
-	  let l:curly_spacing = ' '
-	end
-
     if g:tsuquyomi_single_quote_import
       let l:expression = "import {".l:curly_spacing.l:block.identifier.l:curly_spacing."} from '".l:block.path."';"
     else
@@ -407,7 +407,8 @@ function! tsuquyomi#es6import#complete()
     let l:target_import = l:same_path_import_list[0]
     if l:target_import.is_oneliner
       let l:line = getline(l:target_import.brace.end.line)
-      let l:expression = l:line[0:l:target_import.brace.end.offset - 3].', '.l:block.identifier.' '.l:line[l:target_import.brace.end.offset - 1: -1]
+      let l:injection_position = target_import.brace.end.offset - 2 - strlen(l:curly_spacing)
+      let l:expression = l:line[0:l:injection_position].', '.l:block.identifier.l:curly_spacing.l:line[l:target_import.brace.end.offset - 1: -1]
       call setline(l:target_import.brace.end.line, l:expression)
     else
       let l:before_line = getline(l:target_import.brace.end.line - 1)


### PR DESCRIPTION
It looks like `es6import#complete` was not being aware of the `g:tsuquyomi_import_curly_spacing` setting, and so when it was turned off `:TsuImport` was chopping the last member of the existing import.

For example, if `./lib` exports `f1` and `f2`, and the client file has already an import for `f1`:
```ts
import {f1} from './lib';        // NOTE `g:tsuquyomi_import_curly_spacing` is off
```
then, doing `:TsuImport` on `f2` results in this:
```ts
import {f,f2 } from './lib';    // NOTE the missing `1`, and the closing curly spacing
```
instead of this:
```ts
import {f1,f2} from './lib';
```
