### PR TITLE
Show relative paths for :TsuReferences

### DIFF
--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -461,13 +461,15 @@ function! tsuquyomi#references()
 
   " 1. Fetch reference information.
   let l:res = tsuquyomi#tsClient#tsReferences(l:file, l:line, l:offset)
+  let l:project_config_file = tsuquyomi#projectInfo(l:file).configFileName
+  let l:project_root_dir = substitute(l:project_config_file, 'tsconfig.json', '', '')
 
   if(has_key(l:res, 'refs') && len(l:res.refs) != 0)
     let l:location_list = []
     " 2. Make a location list for `setloclist`
     for reference in res.refs
       let l:location_info = {
-            \'filename': reference.file,
+            \'filename': substitute(reference.file, l:project_root_dir, '', ''),
             \'lnum': reference.start.line,
             \'col': reference.start.offset,
             \'text': reference.lineText


### PR DESCRIPTION
Hi!

I love the `:TsuReferences`! It displays a navigable list of file locations where the symbol under cursor is encountered. Very useful! 🤓

For example:
```
/Users/vladgurdiga/src/mixbook_editors/src/components/app/app.tsx|4 col 9| import {Environment} from "../../utils/environment";
/Users/vladgurdiga/src/mixbook_editors/src/components/app/app.tsx|8 col 16| environment: Environment;
/Users/vladgurdiga/src/mixbook_editors/src/components/app/app.tsx|13 col 16| environment: Environment;
/Users/vladgurdiga/src/mixbook_editors/src/components/layouts/layouts.tsx|16 col 9| import {Environment} from "../../utils/environment";
/Users/vladgurdiga/src/mixbook_editors/src/components/layouts/layouts.tsx|42 col 16| environment: Environment;
```
Although correct and functional, the full paths are unnecessary noisy. 😑

This PR makes the file locations look like this:
```
src/components/app/app.tsx|4 col 9| import {Environment} from "../../utils/environment";
src/components/app/app.tsx|8 col 16| environment: Environment;
src/components/app/app.tsx|13 col 16| environment: Environment;
src/components/layouts/layouts.tsx|16 col 9| import {Environment} from "../../utils/environment";
src/components/layouts/layouts.tsx|42 col 16| environment: Environment;
```
Does this look OK? 🤓 