### PR TITLE
TsuReferences: Fix related path

### DIFF
--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -461,15 +461,13 @@ function! tsuquyomi#references()
 
   " 1. Fetch reference information.
   let l:res = tsuquyomi#tsClient#tsReferences(l:file, l:line, l:offset)
-  let l:project_config_file = tsuquyomi#projectInfo(l:file).configFileName
-  let l:project_root_dir = substitute(l:project_config_file, 'tsconfig.json', '', '')
 
   if(has_key(l:res, 'refs') && len(l:res.refs) != 0)
     let l:location_list = []
     " 2. Make a location list for `setloclist`
     for reference in res.refs
       let l:location_info = {
-            \'filename': substitute(reference.file, l:project_root_dir, '', ''),
+            \'filename': fnamemodify(reference.file, ':~:.'),
             \'lnum': reference.start.line,
             \'col': reference.start.offset,
             \'text': reference.lineText


### PR DESCRIPTION
This is a fix to an earlier PR intented to shorten the file paths in `:TsuReferences` output: https://github.com/Quramy/tsuquyomi/pull/141. That PR introduced an issue nicely outlined by @nickspoons in [a comment](https://github.com/Quramy/tsuquyomi/pull/141#issuecomment-301966916) on it.

Kudos to @nickspoons: for pointing this out and the fix suggestion.