### PR TITLE
Add TsuImplementation and TsuTypeDefinition

### DIFF
--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -427,7 +427,7 @@ endfunction
 " ### Complete }}}
 
 " #### Definition {{{
-function! tsuquyomi#getDefinition(tsClientFunction)
+function! tsuquyomi#gotoDefinition(tsClientFunction)
   if len(s:checkOpenAndMessage([expand('%:p')])[1])
     return
   endif
@@ -463,11 +463,11 @@ function! tsuquyomi#getDefinition(tsClientFunction)
 endfunction
 
 function! tsuquyomi#definition()
-  call tsuquyomi#getDefinition(function('tsuquyomi#tsClient#tsDefinition'))
+  call tsuquyomi#gotoDefinition(function('tsuquyomi#tsClient#tsDefinition'))
 endfunction
 
 function! tsuquyomi#typeDefinition()
-  call tsuquyomi#getDefinition(function('tsuquyomi#tsClient#tsTypeDefinition'))
+  call tsuquyomi#gotoDefinition(function('tsuquyomi#tsClient#tsTypeDefinition'))
 endfunction
 
 function! tsuquyomi#goBack()

--- a/autoload/tsuquyomi/config.vim
+++ b/autoload/tsuquyomi/config.vim
@@ -167,8 +167,12 @@ function! tsuquyomi#config#createBufLocalCommand()
   command! -buffer TsuDefinition           :call tsuquyomi#definition()
   command! -buffer TsuquyomiGoBack         :call tsuquyomi#goBack()
   command! -buffer TsuGoBack               :call tsuquyomi#goBack()
+  command! -buffer TsuquyomiImplementation :call tsuquyomi#implementation()
+  command! -buffer TsuImplementation       :call tsuquyomi#implementation()
   command! -buffer TsuquyomiReferences     :call tsuquyomi#references()
   command! -buffer TsuReferences           :call tsuquyomi#references()
+  command! -buffer TsuquyomiTypeDefinition :call tsuquyomi#typeDefinition()
+  command! -buffer TsuTypeDefinition       :call tsuquyomi#typeDefinition()
   command! -buffer TsuquyomiGeterr         :call tsuquyomi#geterr()
   command! -buffer TsuGeterr               :call tsuquyomi#geterr()
   command! -buffer TsuquyomiGeterrProject  :call tsuquyomi#geterrProject()
@@ -194,7 +198,9 @@ endfunction
 
 function! tsuquyomi#config#createBufLocalMap()
   noremap <silent> <buffer> <Plug>(TsuquyomiDefinition)     :TsuquyomiDefinition <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiTypeDefinition) :TsuquyomiTypeDefinition <CR>
   noremap <silent> <buffer> <Plug>(TsuquyomiGoBack)         :TsuquyomiGoBack <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiImplementation) :TsuquyomiImplementation <CR>
   noremap <silent> <buffer> <Plug>(TsuquyomiReferences)     :TsuquyomiReferences <CR>
   noremap <silent> <buffer> <Plug>(TsuquyomiRenameSymbol)   :TsuquyomiRenameSymbol <CR>
   noremap <silent> <buffer> <Plug>(TsuquyomiRenameSymbolC)  :TsuquyomiRenameSymbolC <CR>

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -76,7 +76,7 @@ If you use |NeoBundle| for plugin management, append the following to `.vimrc` .
 	\     'unix' : 'gmake',
 	\    },
 	\ }
-	
+
 	NeoBundle 'Quramy/tsuquyomi'
 >
 And execute the Ex command |:NeoBundleInstall| .
@@ -150,17 +150,30 @@ COMMANDS					*tsuquyomi-commands*
 :TsuquyomiDefinition
 		Navigate to the location where the symbol is defined.
 
+						*:TsuquyomiTypeDefinition*
+						*:TsuTypeDefinition*
+:TsuquyomiTypeDefinition
+		Navigate to the location where the type of the symbol is
+		defined.
+
 						*:TsuquyomiGoBack*
 						*:TsuGoBack*
 :TsuquyomiGoBack
 		Move the cursor position to the location where
-		the last |:TsuquyomiDefinition| was called.
+		the last |:TsuquyomiDefinition| or |:TsuquyomiTypeDefinition|
+		was called.
+
+						*:TsuquyomiImplementation*
+						*:TsuImplementation*
+:TsuquyomiImplementation
+		Navigate to the locations where an interface is implemented.
+		The result is loaded into the |location-list| .
 
 						*:TsuquyomiReferences*
 						*:TsuReferences*
 :TsuquyomiReferences
 		Navigate to the locations where the symbol is referenced.
-		The result is shown to |location-list| .
+		The result is loaded into the |location-list| .
 
 						*:TsuquyomiRenameSymbol*
 						*:TsuRenameSymbol*
@@ -225,7 +238,7 @@ VARIABLES					*tsuquyomi-variables*
 g:tsuquyomi_auto_open		(default 1)
 		Whether automatically TSServer opens the file of the current
 		buffer, when the buffer is opened in Vim
-		If you set this option to 0, you should manually exec the 
+		If you set this option to 0, you should manually exec the
 		|:TsuquyomiOpen| command after opening buffers.
 
 					*g:tsuquyomi_use_local_typescript*
@@ -235,10 +248,10 @@ g:tsuquyomi_use_local_typescript (default 1)
 		* 0: Tsuquyomi does not search `tsserver.js`.
 		* 1: Tsuquyomi searches the root directory(which has
 		     `package.json`) of the project from the current directory.
-		     Then, it searches 
+		     Then, it searches
 		     `node_modules/typescript/bin/tsserver.js` from the
-		     project root. 
-		     If not hit, Tsuquyomi determines `tsserver.js` path from 
+		     project root.
+		     If not hit, Tsuquyomi determines `tsserver.js` path from
 		     |g:tsuquyomi_use_dev_node_module| option.
 
 					*g:tsuquyomi_use_dev_node_module*
@@ -252,7 +265,7 @@ g:tsuquyomi_use_dev_node_module	(default 0)
 		     :cd ~/.vim/bundle/tsuquyomi
 		     :!npm install
 <
-		* 2: Tsuquyomi uses `tsserver.js` whose path is 
+		* 2: Tsuquyomi uses `tsserver.js` whose path is
 		     |g:tsuquyomi_tsserver_path| .
 
 						*g:tsuquyomi_tsserver_path*
@@ -262,7 +275,7 @@ g:tsuquyomi_tsserver_path	(default `''`)
 		For example,
 >
 		let g:tsuquyomi_use_dev_node_module = 2
-		let g:tsuquyomi_tsserver_path = 
+		let g:tsuquyomi_tsserver_path =
 		\ '~/typescript/built/local/tsserver.js'
 <
 
@@ -272,7 +285,8 @@ g:tsuquyomi_nodejs_path		(default 'node')
 
 						*g:tsuquyomi_definition_split*
 g:tsuquyomi_definition_split	(default 0)
-		A way to open a target file when |:TsuquyomiDefinition|.
+		A way to open a target file when navigating with
+		|:TsuquyomiDefinition| or |:TsuquyomiTypeDefinition|.
 		* 0: |:edit|
 		* 1: |:split|
 		* 2: |:vplit|
@@ -306,7 +320,7 @@ g:tsuquyomi_disable_quickfix	(default 0)
 
 						*g:tsuquyomi_save_onrename*
 g:tsuquyomi_save_onrename	(default 0)
-		If set, Tsuquyomi saves arbitrarily the files which have the 
+		If set, Tsuquyomi saves arbitrarily the files which have the
 		replaced symbols by |:TsuquyomiRenameSymbol| .
 		If not set, Tsuquyomi shows replaced files with |:split|.
 		You can save them with |:wa| after your review changes.
@@ -331,7 +345,7 @@ g:tsuquyomi_ignore_missing_modules (default 0)
 						*g:tsuquyomi_use_vimproc*
 g:tsuquyomi_use_vimproc (default 0)
 		If set, Tsuquyomi will use vimproc instead of vim8 default
-		jobs. 
+		jobs.
 
 
 ------------------------------------------------------------------------------
@@ -341,15 +355,25 @@ Normal mode key mappings.
 
 						*<Plug>(TsuquyomiDefinition)*
 <Plug>(TsuquyomiDefinition)
-		Navigate to the location where the symbol on the cursor is
+		Navigate to the location where the symbol under the cursor is
 		defined. See |:TsuquyomiDefinition|.
+
+						*<Plug>(TsuquyomiTypeDefinition)*
+<Plug>(TsuquyomiTypeDefinition)
+		Navigate to the location where the type of the symbol under the
+		cursor is defined. See |:TsuquyomiTypeDefinition|.
 
 <Plug>(TsuquyomiGoBack)				*<Plug>(TsuquyomiGoBack)*
 		See |:TsuquyomiGoBack|.
 
+						*<Plug>(TsuquyomiImplementation)*
+<Plug>(TsuquyomiImplementation)
+		Show a list of locations where the interface under the cursor is
+		implemented. See |:TsuquyomiImplementation|.
+
 						*<Plug>(TsuquyomiReferences)*
 <Plug>(TsuquyomiReferences)
-		Show a list of locations where the symbol on the cursor is
+		Show a list of locations where the symbol under the cursor is
 		referenced. See |:TsuquyomiReferences|.
 
 					*<Plug>(TsuquyomiRenameSymbol)*
@@ -362,7 +386,6 @@ Normal mode key mappings.
 		Rename the identifier under the cursor to a new name.
 		Please see |:TsuquyomiRenameSymbolC|.
 
-
 						*<Plug>(TsuquyomiQuickFix)*
 <Plug>(TsuquyomiQuickFix)
 		Apply quick fix under the cursor if it's available.
@@ -370,7 +393,7 @@ Normal mode key mappings.
 
 						*<Plug>(TsuquyomiImport)*
 <Plug>(TsuquyomiImport)
-		Generate ES6 import declaration whose alias is under 
+		Generate ES6 import declaration whose alias is under
 		the cursor. See |:TsuquyomiImport|.
 
 						*<Plug>(TsuquyomiSignatureHelp)*
@@ -414,7 +437,7 @@ tsuquyomi#hint					*tsuquyomi#hint*
 		Returns information about symbol under the corsor. This
 		function is so similar to |tsuquyomi#ballonexpr|, but
 		This function works in not only GVim but also terminal Vim.
-		
+
 		For example,
 >
 		autocmd FileType typescript nmap <buffer> <Leader>t :
@@ -433,7 +456,7 @@ EXAMPLES					*tsuquyomi-examples*
 						*tsuquyomi-examples-complete*
 You can configure tsuquyomi completion, using |completeopt| .
 
-	When completion in call of some method, show the method signature to 
+	When completion in call of some method, show the method signature to
 	the preview window.
 >
 	autocmd FileType typescript setlocal completeopt+=preview


### PR DESCRIPTION
The tsserver includes 'implementation' and 'typeDefinition' functions, which are similar to the already implemented 'references' and 'definition' functions respectively. This will close #152 

Note that I have refactored the existing `tsuquyomi#definition` and `tsuquyomi#references` functions, since most of their content was duplicated across functions. They are now called `tsuquyomi#gotoDefinition` and `tsuquyomi#getLocations`, and each take a tsClient function as an argument. @Quramy, if you feel this makes the code difficult to read I will separate them into their own functions.