### PR TITLE
Fix #177

### DIFF
--- a/autoload/tsuquyomi/tsClient.vim
+++ b/autoload/tsuquyomi/tsClient.vim
@@ -211,7 +211,7 @@ endfunction
 function! tsuquyomi#tsClient#sendCommandSyncResponse(cmd, args)
   let l:input = s:JSON.encode({'command': a:cmd, 'arguments': a:args, 'type': 'request', 'seq': s:request_seq})
   call tsuquyomi#perfLogger#record('beforeCmd:'.a:cmd)
-  let l:stdout_list = tsuquyomi#tsClient#sendRequest(l:input, 0.0001, 1000, 1)
+  let l:stdout_list = tsuquyomi#tsClient#sendRequest(l:input, str2float("0.0001"), 1000, 1)
   call tsuquyomi#perfLogger#record('afterCmd:'.a:cmd)
   let l:length = len(l:stdout_list)
   if l:length == 1
@@ -252,7 +252,7 @@ endfunction
 
 function! tsuquyomi#tsClient#sendCommandOneWay(cmd, args)
   let l:input = s:JSON.encode({'command': a:cmd, 'arguments': a:args, 'type': 'request', 'seq': s:request_seq})
-  call tsuquyomi#tsClient#sendRequest(l:input, 0.01, 0, 0)
+  call tsuquyomi#tsClient#sendRequest(l:input, str2float("0.01"), 0, 0)
   return []
 endfunction
 

--- a/plugin/tsuquyomi.vim
+++ b/plugin/tsuquyomi.vim
@@ -35,7 +35,7 @@ let g:tsuquyomi_tsserver_debug =
 let g:tsuquyomi_nodejs_path = 
       \ get(g:, 'tsuquyomi_nodejs_path', 'node')
 let g:tsuquyomi_waittime_after_open = 
-      \ get(g:, 'tsuquyomi_waittime_after_open', 0.01)
+      \ get(g:, 'tsuquyomi_waittime_after_open', str2float("0.01"))
 let g:tsuquyomi_completion_chunk_size = 
       \ get(g:, 'tsuquyomi_completion_chunk_size', 20)
 let g:tsuquyomi_completion_detail = 

--- a/test/tsClient/vest/sendCommand.spec.vim
+++ b/test/tsClient/vest/sendCommand.spec.vim
@@ -15,7 +15,7 @@ Context Vesting.run()
   End
 
   It checks to sendCommandSyncResponse successfully
-    let res_list = tsuquyomi#tsClient#sendCommandSyncEvents('geterr', {'files': ['hoge'], 'delay': 50}, 0.01, 0)
+    let res_list = tsuquyomi#tsClient#sendCommandSyncEvents('geterr', {'files': ['hoge'], 'delay': 50}, str2float("0.01"), 0)
     Should len(res_list) == 0
     call tsuquyomi#tsClient#stopTss()
   End

--- a/test/tsClient/vest/sendRequest.spec.vim
+++ b/test/tsClient/vest/sendRequest.spec.vim
@@ -2,7 +2,7 @@ scriptencoding utf-8
 
 Context Vesting.run()
   It checks to sendRequest successfully
-    let res = tsuquyomi#tsClient#sendRequest('{"command": "open", "arguments": { "file": "test/resrouces/SimpleModule.ts"}}', 0.01, 0, 0)
+    let res = tsuquyomi#tsClient#sendRequest('{"command": "open", "arguments": { "file": "test/resrouces/SimpleModule.ts"}}', str2float("0.01"), 0, 0)
     Should res == []
     call tsuquyomi#tsClient#stopTss()
   End


### PR DESCRIPTION
It fixes the error:

```
Error detected while processing /Users/username/.vim/bundle/tsuquyomi/plugin/tsuquyomi.vim:
line   38:
E806: using Float as a String
E116: Invalid arguments for function get(g:, 'tsuquyomi_waittime_after_open', 0.01)
E15: Invalid expression: get(g:, 'tsuquyomi_waittime_after_open', 0.01)
Press ENTER or type command to continue
```

The error occured when the vim started.

Also, because of this error, the C-] (go to definition, :TsuDefinition) doesn't work. This fix fixes it as well. 