### PR TITLE
Add function to split and jump to definition

### DIFF
--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -427,7 +427,7 @@ endfunction
 " ### Complete }}}
 
 " #### Definition {{{
-function! tsuquyomi#gotoDefinition(tsClientFunction)
+function! tsuquyomi#gotoDefinition(tsClientFunction, splitMode)
   if len(s:checkOpenAndMessage([expand('%:p')])[1])
     return
   endif
@@ -438,23 +438,23 @@ function! tsuquyomi#gotoDefinition(tsClientFunction)
   let l:line = line('.')
   let l:offset = col('.')
   let l:res_list = a:tsClientFunction(l:file, l:line, l:offset)
+  let l:definition_split = a:splitMode > 0 ? a:splitMode : g:tsuquyomi_definition_split
 
   if(len(l:res_list) == 1)
     " If get result, go to the location.
     let l:info = l:res_list[0]
-    if l:file == l:info.file
-      " Same file
+    if a:splitMode == 0 && l:file == l:info.file
+      " Same file without split
       call tsuquyomi#bufManager#winPushNavDef(bufwinnr(bufnr('%')), l:file, {'line': l:line, 'col': l:offset})
       call cursor(l:info.start.line, l:info.start.offset)
-    elseif g:tsuquyomi_definition_split == 0
+    elseif l:definition_split == 0
       call tsuquyomi#bufManager#winPushNavDef(bufwinnr(bufnr('%')), l:file, {'line': l:line, 'col': l:offset})
       execute 'edit +call\ cursor('.l:info.start.line.','.l:info.start.offset.') '.l:info.file
-    elseif g:tsuquyomi_definition_split == 1
-      " If other file, split window
+    elseif l:definition_split == 1
       execute 'split +call\ cursor('.l:info.start.line.','.l:info.start.offset.') '.l:info.file
-    elseif g:tsuquyomi_definition_split == 2
+    elseif l:definition_split == 2
       execute 'vsplit +call\ cursor('.l:info.start.line.','.l:info.start.offset.') '.l:info.file
-    elseif g:tsuquyomi_definition_split == 3
+    elseif l:definition_split == 3
       execute 'tabedit +call\ cursor('.l:info.start.line.','.l:info.start.offset.') '.l:info.file
     endif
   else
@@ -463,11 +463,15 @@ function! tsuquyomi#gotoDefinition(tsClientFunction)
 endfunction
 
 function! tsuquyomi#definition()
-  call tsuquyomi#gotoDefinition(function('tsuquyomi#tsClient#tsDefinition'))
+  call tsuquyomi#gotoDefinition(function('tsuquyomi#tsClient#tsDefinition'), 0)
+endfunction
+
+function! tsuquyomi#splitDefinition()
+  call tsuquyomi#gotoDefinition(function('tsuquyomi#tsClient#tsDefinition'), 1)
 endfunction
 
 function! tsuquyomi#typeDefinition()
-  call tsuquyomi#gotoDefinition(function('tsuquyomi#tsClient#tsTypeDefinition'))
+  call tsuquyomi#gotoDefinition(function('tsuquyomi#tsClient#tsTypeDefinition'), 0)
 endfunction
 
 function! tsuquyomi#goBack()

--- a/autoload/tsuquyomi/config.vim
+++ b/autoload/tsuquyomi/config.vim
@@ -163,60 +163,66 @@ function! tsuquyomi#config#createBufLocalCommand()
   command! -buffer -nargs=1 TsuquyomiSearch                   :call tsuquyomi#navtoByLoclistContain(<f-args>)
   command! -buffer -nargs=1 TsuSearch                         :call tsuquyomi#navtoByLoclistContain(<f-args>)
 
-  command! -buffer TsuquyomiDefinition     :call tsuquyomi#definition()
-  command! -buffer TsuDefinition           :call tsuquyomi#definition()
-  command! -buffer TsuquyomiGoBack         :call tsuquyomi#goBack()
-  command! -buffer TsuGoBack               :call tsuquyomi#goBack()
-  command! -buffer TsuquyomiImplementation :call tsuquyomi#implementation()
-  command! -buffer TsuImplementation       :call tsuquyomi#implementation()
-  command! -buffer TsuquyomiReferences     :call tsuquyomi#references()
-  command! -buffer TsuReferences           :call tsuquyomi#references()
-  command! -buffer TsuquyomiTypeDefinition :call tsuquyomi#typeDefinition()
-  command! -buffer TsuTypeDefinition       :call tsuquyomi#typeDefinition()
-  command! -buffer TsuquyomiGeterr         :call tsuquyomi#geterr()
-  command! -buffer TsuGeterr               :call tsuquyomi#geterr()
-  command! -buffer TsuquyomiGeterrProject  :call tsuquyomi#geterrProject()
-  command! -buffer TsuGeterrProject        :call tsuquyomi#geterrProject()
-  command! -buffer TsuquyomiRenameSymbol   :call tsuquyomi#renameSymbol()
-  command! -buffer TsuRenameSymbol         :call tsuquyomi#renameSymbol()
-  command! -buffer TsuquyomiRenameSymbolC  :call tsuquyomi#renameSymbolWithComments()
-  command! -buffer TsuRenameSymbolC        :call tsuquyomi#renameSymbolWithComments()
-  command! -buffer TsuquyomiQuickFix       :call tsuquyomi#quickFix()
-  command! -buffer TsuQuickFix             :call tsuquyomi#quickFix()
-  command! -buffer TsuquyomiSignatureHelp  :call tsuquyomi#signatureHelp()
-  command! -buffer TsuSignatureHelp        :call tsuquyomi#signatureHelp()
+  command! -buffer TsuquyomiDefinition      :call tsuquyomi#definition()
+  command! -buffer TsuDefinition            :call tsuquyomi#definition()
+  command! -buffer TsuquyomiSplitDefinition :call tsuquyomi#splitDefinition()
+  command! -buffer TsuSplitDefinition       :call tsuquyomi#splitDefinition()
+  command! -buffer TsuquyomiGoBack          :call tsuquyomi#goBack()
+  command! -buffer TsuGoBack                :call tsuquyomi#goBack()
+  command! -buffer TsuquyomiImplementation  :call tsuquyomi#implementation()
+  command! -buffer TsuImplementation        :call tsuquyomi#implementation()
+  command! -buffer TsuquyomiReferences      :call tsuquyomi#references()
+  command! -buffer TsuReferences            :call tsuquyomi#references()
+  command! -buffer TsuquyomiTypeDefinition  :call tsuquyomi#typeDefinition()
+  command! -buffer TsuTypeDefinition        :call tsuquyomi#typeDefinition()
+  command! -buffer TsuquyomiGeterr          :call tsuquyomi#geterr()
+  command! -buffer TsuGeterr                :call tsuquyomi#geterr()
+  command! -buffer TsuquyomiGeterrProject   :call tsuquyomi#geterrProject()
+  command! -buffer TsuGeterrProject         :call tsuquyomi#geterrProject()
+  command! -buffer TsuquyomiRenameSymbol    :call tsuquyomi#renameSymbol()
+  command! -buffer TsuRenameSymbol          :call tsuquyomi#renameSymbol()
+  command! -buffer TsuquyomiRenameSymbolC   :call tsuquyomi#renameSymbolWithComments()
+  command! -buffer TsuRenameSymbolC         :call tsuquyomi#renameSymbolWithComments()
+  command! -buffer TsuquyomiQuickFix        :call tsuquyomi#quickFix()
+  command! -buffer TsuQuickFix              :call tsuquyomi#quickFix()
+  command! -buffer TsuquyomiSignatureHelp   :call tsuquyomi#signatureHelp()
+  command! -buffer TsuSignatureHelp         :call tsuquyomi#signatureHelp()
 
   " TODO These commands don't work correctly.
-  command! -buffer TsuquyomiRenameSymbolS  :call tsuquyomi#renameSymbolWithStrings()
-  command! -buffer TsuRenameSymbolS        :call tsuquyomi#renameSymbolWithStrings()
-  command! -buffer TsuquyomiRenameSymbolCS :call tsuquyomi#renameSymbolWithCommentsStrings()
-  command! -buffer TsuRenameSymbolCS       :call tsuquyomi#renameSymbolWithCommentsStrings()
+  command! -buffer TsuquyomiRenameSymbolS   :call tsuquyomi#renameSymbolWithStrings()
+  command! -buffer TsuRenameSymbolS         :call tsuquyomi#renameSymbolWithStrings()
+  command! -buffer TsuquyomiRenameSymbolCS  :call tsuquyomi#renameSymbolWithCommentsStrings()
+  command! -buffer TsuRenameSymbolCS        :call tsuquyomi#renameSymbolWithCommentsStrings()
 
-  command! -buffer TsuquyomiImport         :call tsuquyomi#es6import#complete()
-  command! -buffer TsuImport               :call tsuquyomi#es6import#complete()
+  command! -buffer TsuquyomiImport          :call tsuquyomi#es6import#complete()
+  command! -buffer TsuImport                :call tsuquyomi#es6import#complete()
 endfunction
 
 function! tsuquyomi#config#createBufLocalMap()
-  noremap <silent> <buffer> <Plug>(TsuquyomiDefinition)     :TsuquyomiDefinition <CR>
-  noremap <silent> <buffer> <Plug>(TsuquyomiTypeDefinition) :TsuquyomiTypeDefinition <CR>
-  noremap <silent> <buffer> <Plug>(TsuquyomiGoBack)         :TsuquyomiGoBack <CR>
-  noremap <silent> <buffer> <Plug>(TsuquyomiImplementation) :TsuquyomiImplementation <CR>
-  noremap <silent> <buffer> <Plug>(TsuquyomiReferences)     :TsuquyomiReferences <CR>
-  noremap <silent> <buffer> <Plug>(TsuquyomiRenameSymbol)   :TsuquyomiRenameSymbol <CR>
-  noremap <silent> <buffer> <Plug>(TsuquyomiRenameSymbolC)  :TsuquyomiRenameSymbolC <CR>
-  noremap <silent> <buffer> <Plug>(TsuquyomiQuickFix)       :TsuquyomiQuickFix <CR>
-  noremap <silent> <buffer> <Plug>(TsuquyomiSignatureHelp)  :TsuquyomiSignatureHelp <CR>
-  noremap <silent> <buffer> <Plug>(TsuquyomiImport)         :TsuquyomiImport <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiDefinition)      :TsuquyomiDefinition <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiSplitDefinition) :TsuquyomiSplitDefinition <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiTypeDefinition)  :TsuquyomiTypeDefinition <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiGoBack)          :TsuquyomiGoBack <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiImplementation)  :TsuquyomiImplementation <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiReferences)      :TsuquyomiReferences <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiRenameSymbol)    :TsuquyomiRenameSymbol <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiRenameSymbolC)   :TsuquyomiRenameSymbolC <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiQuickFix)        :TsuquyomiQuickFix <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiSignatureHelp)   :TsuquyomiSignatureHelp <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiImport)          :TsuquyomiImport <CR>
 
   " TODO These commands don't work correctly.
-  noremap <silent> <buffer> <Plug>(TsuquyomiRenameSymbolS)  :TsuquyomiRenameSymbolS <CR>
-  noremap <silent> <buffer> <Plug>(TsuquyomiRenameSymbolCS) :TsuquyomiRenameSymbolCS <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiRenameSymbolS)   :TsuquyomiRenameSymbolS <CR>
+  noremap <silent> <buffer> <Plug>(TsuquyomiRenameSymbolCS)  :TsuquyomiRenameSymbolCS <CR>
 endfunction
 
 function! tsuquyomi#config#applyBufLocalDefaultMap()
   if(!exists('g:tsuquyomi_disable_default_mappings'))
     if !hasmapto('<Plug>(TsuquyomiDefinition)')
         map <buffer> <C-]> <Plug>(TsuquyomiDefinition)
+    endif
+    if !hasmapto('<Plug>(TsuquyomiSplitDefinition)')
+        map <buffer> <C-W>] <Plug>(TsuquyomiSplitDefinition)
     endif
     if !hasmapto('<Plug>(TsuquyomiGoBack)')
         map <buffer> <C-t> <Plug>(TsuquyomiGoBack)

--- a/doc/tsuquyomi.jax
+++ b/doc/tsuquyomi.jax
@@ -151,6 +151,12 @@ Prompt:
 :TsuquyomiDefinition
 		シンボルが定義された場所へ遷移させます.
 
+						*:TsuquyomiSplitDefinition*
+						*:TsuSplitDefinition*
+:TsuquyomiSplitDefinition
+                現在のウィンドウを2つに分割します。
+                シンボルが定義されている場所に移動する.
+
 						*:TsuquyomiTypeDefinition*
 						*:TsuTypeDefinition*
 :TsuquyomiTypeDefinition
@@ -348,6 +354,11 @@ g:tsuquyomi_ignore_missing_modules (デフォルト値 0)
 		カーソル直下のシンボルが定義された箇所へ遷移.
 		|:TsuquyomiDefinition|を参照のこと.
 
+						*<Plug>(TsuquyomiSplitDefinition)*
+<Plug>(TsuquyomiSplitDefinition)
+		カーソル直下のシンボルが定義された箇所へ遷移.
+		|:TsuquyomiSplitDefinition|を参照のこと.
+
 					*<Plug>(TsuquyomiTypeDefinition)*
 <Plug>(TsuquyomiTypeDefinition)
 		カーソル直下のシンボルの型定義箇所へ遷移.
@@ -394,6 +405,7 @@ g:tsuquyomi_ignore_missing_modules (デフォルト値 0)
 {lhs}			{rhs}
 --------		-----------------------------
 <C-]>			<Plug>(TsuquyomiDefinition)
+<C-W>]			<Plug>(TsuquyomiSplitDefinition)
 <C-t>			<Plug>(TsuquyomiGoBack)
 <C-^>			<Plug>(TsuquyomiReferences)
 

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -150,6 +150,12 @@ COMMANDS					*tsuquyomi-commands*
 :TsuquyomiDefinition
 		Navigate to the location where the symbol is defined.
 
+						*:TsuquyomiSplitDefinition*
+						*:TsuSplitDefinition*
+:TsuquyomiSplitDefinition
+		Split current window in two. Navigate to the location where
+		the symbol is defined.
+
 						*:TsuquyomiTypeDefinition*
 						*:TsuTypeDefinition*
 :TsuquyomiTypeDefinition
@@ -358,6 +364,12 @@ Normal mode key mappings.
 		Navigate to the location where the symbol under the cursor is
 		defined. See |:TsuquyomiDefinition|.
 
+						*<Plug>(TsuquyomiSplitDefinition)*
+<Plug>(TsuquyomiSplitDefinition)
+		Split current window in two. Navigate to the location where
+		the symbol under the cursor is defined. See
+		|:TsuquyomiSplitDefinition|.
+
 						*<Plug>(TsuquyomiTypeDefinition)*
 <Plug>(TsuquyomiTypeDefinition)
 		Navigate to the location where the type of the symbol under the
@@ -407,6 +419,7 @@ Normal mode default mappings.
 {lhs}			{rhs}
 --------		-----------------------------
 <C-]>			<Plug>(TsuquyomiDefinition)
+<C-W>]			<Plug>(TsuquyomiSplitDefinition)
 <C-t>			<Plug>(TsuquyomiGoBack)
 <C-^>			<Plug>(TsuquyomiReferences)
 


### PR DESCRIPTION
Automatically override the `<CTRL-W>]` mapping to split the window and
jump to the definition, just like default vim does it when using tags.

Fixes #180 

PS. I don't speak Japanese. If this fix is accepted, please fix the strings. :)