### PR TITLE
Override vim's tag jump <C-W><C-]> binding to match <C-W>]

### DIFF
--- a/autoload/tsuquyomi/config.vim
+++ b/autoload/tsuquyomi/config.vim
@@ -229,6 +229,7 @@ function! tsuquyomi#config#applyBufLocalDefaultMap()
     endif
     if !hasmapto('<Plug>(TsuquyomiSplitDefinition)')
         map <buffer> <C-W>] <Plug>(TsuquyomiSplitDefinition)
+        map <buffer> <C-W><C-]> <Plug>(TsuquyomiSplitDefinition)
     endif
     if !hasmapto('<Plug>(TsuquyomiGoBack)')
         map <buffer> <C-t> <Plug>(TsuquyomiGoBack)

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -423,6 +423,7 @@ Normal mode default mappings.
 --------		-----------------------------
 <C-]>			<Plug>(TsuquyomiDefinition)
 <C-W>]			<Plug>(TsuquyomiSplitDefinition)
+<C-W><C-]>		<Plug>(TsuquyomiSplitDefinition)
 <C-t>			<Plug>(TsuquyomiGoBack)
 <C-^>			<Plug>(TsuquyomiReferences)
 


### PR DESCRIPTION
I'm using to keeping control held while jumping to a tag in a split window. This also fills a gap where vim's tag functionality would jump in.