### PR TITLE
fix #194: trailing comma for TsuImport

### DIFF
--- a/autoload/tsuquyomi/es6import.vim
+++ b/autoload/tsuquyomi/es6import.vim
@@ -419,8 +419,17 @@ function! tsuquyomi#es6import#complete()
     else
       let l:before_line = getline(l:target_import.brace.end.line - 1)
       let l:indent = matchstr(l:before_line, '\m^\s*')
-      call setline(l:target_import.brace.end.line - 1, l:before_line.',')
-      call append(l:target_import.brace.end.line - 1, l:indent.l:block.identifier)
+      let l:before_has_trailing_comma = matchstr(l:before_line, ',\s*$')
+      if l:before_has_trailing_comma !=# ''
+        let l:prev_trailing_comma = ''
+        let l:new_trailing_comma = ','
+      else
+        let l:prev_trailing_comma = ','
+        let l:new_trailing_comma = ''
+      endif
+
+      call setline(l:target_import.brace.end.line - 1, l:before_line.l:prev_trailing_comma)
+      call append(l:target_import.brace.end.line - 1, l:indent.l:block.identifier.l:new_trailing_comma)
     endif
   endif
 endfunction


### PR DESCRIPTION
Fixes #194 

This will check if there is a trailing comma on the previous import line before inserting the new import. It will avoid adding an extra comma and also add a trailing comma for itself.