### PR TITLE
Ignore `projectsUpdatedInBackground` events

### DIFF
--- a/autoload/tsuquyomi/tsClient.vim
+++ b/autoload/tsuquyomi/tsClient.vim
@@ -34,6 +34,7 @@ let s:ignore_respons_conditions = []
 call add(s:ignore_respons_conditions, '"type":"event","event":"configFileDiag"')
 call add(s:ignore_respons_conditions, '"type":"event","event":"requestCompleted"')
 call add(s:ignore_respons_conditions, '"type":"event","event":"telemetry"')
+call add(s:ignore_respons_conditions, '"type":"event","event":"projectsUpdatedInBackground"')
 
 " ### Utilites {{{
 function! s:error(msg)


### PR DESCRIPTION
If a file changes in the opened project, `tsserver` emits a [`projectsUpdatedInBackground`](https://github.com/Microsoft/TypeScript/blob/v2.6.1/lib/protocol.d.ts#L1623) event **out of order**. 😑

So if for example I make a `Geterr` request, it’s possible that instead of my response I’d get the `projectsUpdatedInBackground` event as a response. 😶