### PR TITLE
Add the `g:tsuquyomi_case_sensitive_imports` option

### DIFF
--- a/autoload/tsuquyomi/es6import.vim
+++ b/autoload/tsuquyomi/es6import.vim
@@ -126,7 +126,7 @@ function! tsuquyomi#es6import#createImportBlock(text)
   endfor
 
   if g:tsuquyomi_case_sensitive_imports == 1
-    call filter(l:result_list, {idx, val -> val.identifier ==# l:identifier})
+    call filter(l:result_list, 'v:val.identifier ==# l:identifier')
   endif
 
   return l:result_list

--- a/autoload/tsuquyomi/es6import.vim
+++ b/autoload/tsuquyomi/es6import.vim
@@ -124,6 +124,11 @@ function! tsuquyomi#es6import#createImportBlock(text)
       call add(l:result_list, l:importDict)
     endif
   endfor
+
+  if g:tsuquyomi_case_sensitive_imports == 1
+    call filter(l:result_list, {idx, val -> val.identifier ==# l:identifier})
+  endif
+
   return l:result_list
 endfunction
 

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -309,6 +309,11 @@ g:tsuquyomi_completion_case_sensitive	(default 0)
 		Whether to search completion case-sensitively when
 		|tsuquyomi#complete|.
 
+					*g:tsuquyomi_case_sensitive_imports*
+g:tsuquyomi_case_sensitive_imports	(default 0)
+		Whether to search imports case-sensitively when
+		|tsuquyomi#es6import#complete|.
+
 					*g:tsuquyomi_completion_preview*
 g:tsuquyomi_completion_preview		(default 0)
 		Whether to show sigunature in preview when |tsuquyomi#complete|.

--- a/plugin/tsuquyomi.vim
+++ b/plugin/tsuquyomi.vim
@@ -42,6 +42,8 @@ let g:tsuquyomi_completion_detail =
       \ get(g:, 'tsuquyomi_completion_detail', 0)
 let g:tsuquyomi_completion_case_sensitive = 
       \ get(g:, 'tsuquyomi_completion_case_sensitive', 0)
+let g:tsuquyomi_case_sensitive_imports =
+      \ get(g:, 'tsuquyomi_case_sensitive_imports', 0)
 let g:tsuquyomi_completion_preview = 
       \ get(g:, 'tsuquyomi_completion_preview', 0)
 let g:tsuquyomi_definition_split =


### PR DESCRIPTION
Many times import list returned by `tsuquyomi#es6import#complete` contains irrelevant options because of case-insensitive identifier comparison. This option makes the identifier search case-sensitive.