### PR TITLE
Improve doc

### DIFF
--- a/doc/tsuquyomi.jax
+++ b/doc/tsuquyomi.jax
@@ -44,7 +44,7 @@ tsuquyomi は以下の機能を提供します.
 + TSServer からソースコードが持つ情報を参照します.
   (補完, 定義/参照箇所, エラー, etc...)
 
-+ TSServerの起動や停止を行う機能 
++ TSServerの起動や停止を行う機能
 
 ==============================================================================
 インストール 						*tsuquyomi-install*
@@ -65,7 +65,7 @@ Prompt:
     	$ npm -g install typescript
 <
 最後に, tsuquyomiをVim plugin用のディレクトリに配置します.
-もし |NeoBundle| でプラグイン管理をしているのであれば, 
+もし |NeoBundle| でプラグイン管理をしているのであれば,
 `.vimrc` に以下を追記します
 >
 	NeoBundle 'Shougo/vimproc.vim', {
@@ -77,7 +77,7 @@ Prompt:
 	\     'unix' : 'gmake',
 	\    },
 	\ }
-	
+
 	NeoBundle 'Quramy/tsuquyomi'
 >
 |:NeoBundleInstall| を実行し,  プラグインをインストールしてください.
@@ -247,7 +247,7 @@ g:tsuquyomi_use_local_typescript (default 1)
 		     ルートディレクトリ(`package.json`を含むディレクトリ)を
 		     探索します. 次にプロジェクトルートから
 		     `node_modules/typescript/bin/tsserver.js`
-                     を探索します. 見つからない場合は, 
+                     を探索します. 見つからない場合は,
 		     |g:tsuquyomi_use_dev_node_module| に従って`tsserver.js`の
 		     パスを決定します.
 
@@ -264,17 +264,17 @@ g:tsuquyomi_use_dev_node_module	(デフォルト値 0)
 		     :cd ~/.vim/bundle/tsuquyomi
 		     :!npm install
 <
-		* 2: tsuquyomiは|g:tsuquyomi_tsserver_path| で指定された 
+		* 2: tsuquyomiは|g:tsuquyomi_tsserver_path| で指定された
 		     `tsserver.js` を利用します.
 
 						*g:tsuquyomi_tsserver_path*
 g:tsuquyomi_tsserver_path	(デフォルト値 `''`)
-		|g:tsuquyomi_use_dev_node_module|を`2`とした場合, 
+		|g:tsuquyomi_use_dev_node_module|を`2`とした場合,
 		このオプションで`tsserver.js`のパスを設定する必要があります.
 		設定例:
 >
 		let g:tsuquyomi_use_dev_node_module = 2
-		let g:tsuquyomi_tsserver_path = 
+		let g:tsuquyomi_tsserver_path =
 		\ '~/typescript/built/local/tsserver.js'
 <
 
@@ -284,7 +284,7 @@ g:tsuquyomi_nodejs_path		(デフォルト値 "node")
 
 						*g:tsuquyomi_definition_split*
 g:tsuquyomi_definition_split	(デフォルト値 0)
-		|:TsuquyomiDefinition| にて別ファイル定義への遷移時, 
+		|:TsuquyomiDefinition| にて別ファイル定義への遷移時,
 		ウィンドウをどのように開くか.
 		* 0: |:edit|
 		* 1: |:split|
@@ -437,13 +437,13 @@ tsuquyomi#balloonexpr	 			*tsuquyomi#balloonexpr*
 tsuquyomi#hint					*tsuquyomi#hint*
 		カーソル上のシンボルの情報を返却する. |tsuquyomi#balloonexpr|
 		と似ているが, この関数はGVim, 端末上のVimのどちらでも動作する.
-		
+
 		設定例:
 >
 		autocmd FileType typescript nmap <buffer> <Leader>t :
 		\ <C-u>echo tsuquyomi#hint()<CR>
 <
-		Note: This function works in not only GVim but also 
+		Note: This function works in not only GVim but also
 		      terminal Vim.
 
 tsuquyomi#getSupportedCodeFixes		 *tsuquyomi#getSupportedCodeFixes*

--- a/doc/tsuquyomi.jax
+++ b/doc/tsuquyomi.jax
@@ -419,23 +419,23 @@ g:tsuquyomi_locale (デフォルト値 'en')
 tsuquyomi#complete					*tsuquyomi#complete*
 		|completefunc| や|omnifunc|オプションに適用可能な関数.
 		デフォルトでは, |omnifunc|オプションにこの関数をセットしている
-		補完の挙動をカスタマイズする場合, |tsuquyomi-example-complete|
+		補完の挙動をカスタマイズする場合, |tsuquyomi-examples-complete|
 		を参照の事.
 
 tsuquyomi#balloonexpr	 			*tsuquyomi#balloonexpr*
 		マウスカーソル直下のシンボルについて, ツールチップにシンボルの
-		情報を表示させる.  |ballon-expr|にセットして利用する.
+		情報を表示させる.  'balloonexpr' にセットして利用する.
 		設定例:
 >
 		set ballooneval
 		autocmd BufNewFile,BufRead *.ts
-		\ setlocal ballonexpr=tsuquyomi#balloonexpr()
+		\ setlocal balloonexpr=tsuquyomi#balloonexpr()
 <
 		Note: この関数はVimが|+balloon_eval| オプション付きでコンパイル
 		      されている場合のみ利用可能である.
 
 tsuquyomi#hint					*tsuquyomi#hint*
-		カーソル上のシンボルの情報を返却する. |tsuquyomi#ballonexpr|
+		カーソル上のシンボルの情報を返却する. |tsuquyomi#balloonexpr|
 		と似ているが, この関数はGVim, 端末上のVimのどちらでも動作する.
 		
 		設定例:

--- a/doc/tsuquyomi.jax
+++ b/doc/tsuquyomi.jax
@@ -107,7 +107,7 @@ Prompt:
 						*:TsuStatusServer*
 :TsuquyomiStatusServer
 		TSServerの起動状態を表示します.
-		TSServerが起動している場合, 'reading' のメッセージが
+		TSServerが起動している場合, "reading" のメッセージが
 		表示されます.
 
 						*:TsuquyomiOpen*
@@ -279,7 +279,7 @@ g:tsuquyomi_tsserver_path	(デフォルト値 `''`)
 <
 
 						*g:tsuquyomi_nodejs_path*
-g:tsuquyomi_nodejs_path		(デフォルト値 'node')
+g:tsuquyomi_nodejs_path		(デフォルト値 "node")
 		Node.js の実行パス.
 
 						*g:tsuquyomi_definition_split*
@@ -294,7 +294,7 @@ g:tsuquyomi_definition_split	(デフォルト値 0)
 					*g:tsuquyomi_completion_detail*
 g:tsuquyomi_completion_detail		(デフォルト値 0)
 		|tsuquyomi#complete|実行時に詳細な補完メニューを作成するかどうか.
-		このオプションは|completeopt|に "menu"が含まれるときにのみ
+		このオプションは 'completeopt' に "menu" が含まれるときにのみ
 		意味を持つ.
 		NOTE: このオプションを1に設定した場合, 補完速度は遅くなる
 
@@ -307,8 +307,8 @@ g:tsuquyomi_completion_case_sensitive	(デフォルト値 0)
 g:tsuquyomi_completion_preview		(デフォルト値 0)
 		|tsuquyomi#complete|実行時にシグネチャの情報をプレビューに表示
 		するかどうか.
-		このオプションは|completeopt|に "menu"と"preview"が含まれるとき
-		にのみ意味を持つ.
+		このオプションは 'completeopt' に "menu" と "preview" が含まれ
+		るときにのみ意味を持つ.
 		NOTE: このオプションを1に設定した場合, 補完速度は少し遅くなる
 
 						*g:tsuquyomi_disable_default_mappings*
@@ -345,7 +345,7 @@ g:tsuquyomi_ignore_missing_modules (デフォルト値 0)
 		import対象の型定義ファイルが存在していないケースで有用。
 
 						*g:tsuquyomi_locale*
-g:tsuquyomi_locale (デフォルト値 'en')
+g:tsuquyomi_locale (デフォルト値 "en")
 		エラーメッセージのLCID。
 
 ------------------------------------------------------------------------------
@@ -417,10 +417,10 @@ g:tsuquyomi_locale (デフォルト値 'en')
 関数 							*tsuquyomi-functions*
 
 tsuquyomi#complete					*tsuquyomi#complete*
-		|completefunc| や|omnifunc|オプションに適用可能な関数.
-		デフォルトでは, |omnifunc|オプションにこの関数をセットしている
-		補完の挙動をカスタマイズする場合, |tsuquyomi-examples-complete|
-		を参照の事.
+		'completefunc' や 'omnifunc' オプションに適用可能な関数.
+		デフォルトでは, 'omnifunc' オプションにこの関数をセットしてい
+		る補完の挙動をカスタマイズする場合,
+		|tsuquyomi-examples-complete| を参照の事.
 
 tsuquyomi#balloonexpr	 			*tsuquyomi#balloonexpr*
 		マウスカーソル直下のシンボルについて, ツールチップにシンボルの
@@ -457,7 +457,7 @@ Todo
 EXAMPLES					*tsuquyomi-examples*
 
 						*tsuquyomi-examples-complete*
-補完の挙動は |completeopt| オプションで設定する.
+補完の挙動は 'completeopt' オプションで設定する.
 
 	メソッド呼び出しの補完時, メソッド定義をプレビューウィンドウに表示.
 >

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -295,7 +295,7 @@ g:tsuquyomi_definition_split	(default 0)
 		|:TsuquyomiDefinition| or |:TsuquyomiTypeDefinition|.
 		* 0: |:edit|
 		* 1: |:split|
-		* 2: |:vplit|
+		* 2: |:vsplit|
 		* 3: |:tabedit|
 
 					*g:tsuquyomi_completion_detail*
@@ -440,24 +440,24 @@ tsuquyomi#complete				*tsuquyomi#complete*
 		By the default, Tsuquyomi set this function to the |omnifunc|
 		option.
 		If you want to customize completions, see
-		|tsuquyomi-example-complete|.
+		|tsuquyomi-examples-complete|.
 
 tsuquyomi#balloonexpr	 			*tsuquyomi#balloonexpr*
 		Returns information about symbol under then mouse cursor for
 		tooltip popover window.
-		This is used as the rhs for |balloon-expr|.
+		This is used as the rhs for 'balloonexpr'.
 		For example,
 >
 		set ballooneval
 		autocmd BufNewFile,BufRead *.ts
-		\ setlocal ballonexpr=tsuquyomi#balloonexpr()
+		\ setlocal balloonexpr=tsuquyomi#balloonexpr()
 <
 		Note: This function works only if your Vim is compiled with
 		      |+balloon_eval|.
 
 tsuquyomi#hint					*tsuquyomi#hint*
 		Returns information about symbol under the cursor. This
-		function is so similar to |tsuquyomi#ballonexpr|, but
+		function is so similar to |tsuquyomi#balloonexpr|, but
 		This function works in not only GVim but also terminal Vim.
 
 		For example,

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -108,7 +108,7 @@ COMMANDS					*tsuquyomi-commands*
 						*:TsuStatusServer*
 :TsuquyomiStatusServer
 		Show TSServer status.
-		When TSServer is running, the message 'reading' will be
+		When TSServer is running, the message "reading" will be
 		displayed.
 
 						*:TsuquyomiOpen*
@@ -286,7 +286,7 @@ g:tsuquyomi_tsserver_path	(default `''`)
 <
 
 						*g:tsuquyomi_nodejs_path*
-g:tsuquyomi_nodejs_path		(default 'node')
+g:tsuquyomi_nodejs_path		(default "node")
 		A path to Node.js.
 
 						*g:tsuquyomi_definition_split*
@@ -301,7 +301,7 @@ g:tsuquyomi_definition_split	(default 0)
 					*g:tsuquyomi_completion_detail*
 g:tsuquyomi_completion_detail		(default 0)
 		Whether to show details of complete menu when |tsuquyomi#complete|.
-		This options makes sence when |completeopt| includes "menu".
+		This options makes sence when 'completeopt' includes "menu".
 		NOTE: If it's set, completions gets slow.
 
 					*g:tsuquyomi_completion_case_sensitive*
@@ -317,7 +317,7 @@ g:tsuquyomi_case_sensitive_imports	(default 0)
 					*g:tsuquyomi_completion_preview*
 g:tsuquyomi_completion_preview		(default 0)
 		Whether to show sigunature in preview when |tsuquyomi#complete|.
-		This options makes sence when |completeopt| includes "menu"
+		This options makes sence when 'completeopt' includes "menu"
 		and "preview".
 		NOTE: If it's set, completions gets a little slow.
 
@@ -359,7 +359,7 @@ g:tsuquyomi_use_vimproc (default 0)
 		jobs.
 
 						*g:tsuquyomi_locale*
-g:tsuquyomi_locale (default 'en')
+g:tsuquyomi_locale (default "en")
 		LCID for deagonistics localization.
 
 ------------------------------------------------------------------------------
@@ -436,8 +436,8 @@ Normal mode default mappings.
 FUNCTIONS					*tsuquyomi-functions*
 
 tsuquyomi#complete				*tsuquyomi#complete*
-		It's applicable for the |completefunc| or |omnifunc| option.
-		By the default, Tsuquyomi set this function to the |omnifunc|
+		It's applicable for the 'completefunc' or 'omnifunc' option.
+		By the default, Tsuquyomi set this function to the 'omnifunc'
 		option.
 		If you want to customize completions, see
 		|tsuquyomi-examples-complete|.
@@ -476,7 +476,7 @@ Todo
 EXAMPLES					*tsuquyomi-examples*
 
 						*tsuquyomi-examples-complete*
-You can configure tsuquyomi completion, using |completeopt| .
+You can configure tsuquyomi completion, using 'completeopt' .
 
 	When completion in call of some method, show the method signature to
 	the preview window.


### PR DESCRIPTION
Fix some problems in help document.
There are still some broken link, but I didn't fixed it:
- `tsuquyomi#es6import#complete` (doc/tsuquyomi.txt#L315)
- `:TsuquyomiImport` (doc/tsuquyomi.txt#L342, L417, doc/tsuquyomi.jax#L404)
- `:TsuImport` (doc/tsuquyomi.jax#L333)

BTW, [vimhelplint](https://github.com/machakann/vim-vimhelplint) is useful 😃 