### PR TITLE
Add support for import paths relative to `baseUrl`

### DIFF
--- a/autoload/tsuquyomi/es6import.vim
+++ b/autoload/tsuquyomi/es6import.vim
@@ -208,7 +208,7 @@ endfunction
 function! s:getBaseUrlImportPath(module_absolute_path)
   let [l:tsconfig, l:tsconfig_file_path] = s:getTsconfig(a:module_absolute_path)
 
-  if l:tsconfig_file_path == ''
+  if empty(l:tsconfig) || l:tsconfig_file_path == ''
     return ''
   endif
 
@@ -233,7 +233,14 @@ function! s:getTsconfig(module_absolute_path)
       echom '[Tsuquyomi] Cannot find project’s tsconfig.json to compute baseUrl import path.'
     endif
 
-    let s:tsconfig = s:JSON.decode(join(readfile(s:tsconfig_file_path),''))
+    let l:json = join(readfile(s:tsconfig_file_path),'')
+
+    try
+      let s:tsconfig = s:JSON.decode(l:json)
+    catch
+      echom '[Tsuquyomi] Cannot parse project’s tsconfig.json. Does it have comments?'
+    endtry
+
   endif
 
   return [s:tsconfig, s:tsconfig_file_path]

--- a/autoload/tsuquyomi/es6import.vim
+++ b/autoload/tsuquyomi/es6import.vim
@@ -211,12 +211,12 @@ function! s:getBaseUrlImportPath(module_absolute_path)
     let l:project_info = tsuquyomi#tsClient#tsProjectInfo(a:module_absolute_path, 0)
     let l:tsconfig_file_path = l:project_info.configFileName
     let s:tsconfig = s:JSON.decode(join(readfile(l:tsconfig_file_path),''))
-
-    let l:project_root_path = fnamemodify(l:tsconfig_file_path, ":h")."/"
-    " We assume that baseUrl is a path relative to tsconfig.json path.
-    let l:base_url_config = has_key(s:tsconfig.compilerOptions, 'baseUrl') ? s:tsconfig.compilerOptions.baseUrl : '.'
-    let l:base_url_path = simplify(l:project_root_path.l:base_url_config)
   endif
+
+  let l:project_root_path = fnamemodify(l:tsconfig_file_path, ":h")."/"
+  " We assume that baseUrl is a path relative to tsconfig.json path.
+  let l:base_url_config = has_key(s:tsconfig.compilerOptions, 'baseUrl') ? s:tsconfig.compilerOptions.baseUrl : '.'
+  let l:base_url_path = simplify(l:project_root_path.l:base_url_config)
 
   return s:removeTSExtensions(substitute(a:module_absolute_path, l:base_url_path, '', ''))
 endfunction

--- a/autoload/tsuquyomi/es6import.vim
+++ b/autoload/tsuquyomi/es6import.vim
@@ -218,7 +218,7 @@ function! s:getBaseUrlImportPath(module_absolute_path)
     let l:base_url_path = simplify(l:project_root_path.l:base_url_config)
   endif
 
-  return substitute(a:module_absolute_path, l:base_url_path, '', '')
+  return s:removeTSExtensions(substitute(a:module_absolute_path, l:base_url_path, '', ''))
 endfunction
 
 function! s:findExportingFileForModule(module, current_module_file, module_directory_path)

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -341,6 +341,11 @@ g:tsuquyomi_single_quote_import		(default 0)
 		If set, Tsuquyomi generates import block using single quotes
 		instead of double quotes when |:TsuquyomiImport|.
 
+						*g:tsuquyomi_baseurl_import_path*
+g:tsuquyomi_baseurl_import_path		(default 0)
+		If set, |:TsuquyomiImport| will use module paths relative to
+		`baseUrl` setting in tsconfig.json.
+
 						*g:tsuquyomi_javascript_support*
 g:tsuquyomi_javascript_support	(default 0)
 		If set, Tsuquyomi will also be enabled for JavaScript files.

--- a/plugin/tsuquyomi.vim
+++ b/plugin/tsuquyomi.vim
@@ -62,6 +62,8 @@ let g:tsuquyomi_ignore_missing_modules =
       \ get(g:, 'tsuquyomi_ignore_missing_modules', 0)
 let g:tsuquyomi_shortest_import_path = 
       \ get(g:, 'tsuquyomi_shortest_import_path', 0)
+let g:tsuquyomi_baseurl_import_path = 
+      \ get(g:, 'tsuquyomi_baseurl_import_path', 0)
 let g:tsuquyomi_use_vimproc =
       \ get(g:, 'tsuquyomi_use_vimproc', 0)
 let g:tsuquyomi_locale =


### PR DESCRIPTION
## Backgound

This is nice to have when your project uses imports relative to [`baseUrl`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url). :neckbeard: 

For example, if your `tsconfig.json` has the `compilerOptions.baseUrl` of `"./src/"`, and somewhere in `src/api/json/some_file.ts` you need to import `src/models/synchronizable_model.ts`, you can use this concise import:
```ts
import {ClientId} from "models/synchronizable_model";
```
instead of this long-and-hard-to-follow import:
```ts
import {ClientId} from "../../../src/models/synchronizable_model";
```
…which is neat! 🤓

## Feature

This PR adds the `g:tsuquyomi_baseurl_import_path` option, which when set to `1` makes `:TsuImport` create a concise import instead of the a long-and-hard-to-follow one. ✨ 