### PR TITLE
Fix bug with project paths containing spaces. Fixes #147

### DIFF
--- a/autoload/tsuquyomi/config.vim
+++ b/autoload/tsuquyomi/config.vim
@@ -108,11 +108,7 @@ function! tsuquyomi#config#tsscmd()
     if l:prj_dir !=# ''
       let l:searched_tsserver_path = s:Filepath.join(l:prj_dir, 'node_modules/typescript/bin/tsserver')
       if filereadable(l:searched_tsserver_path)
-        if !s:is_vim8
-          return g:tsuquyomi_nodejs_path.' "'.l:searched_tsserver_path.'"'
-        else
-          return g:tsuquyomi_nodejs_path.' '.l:searched_tsserver_path
-        endif
+        return g:tsuquyomi_nodejs_path.' "'.l:searched_tsserver_path.'"'
       endif
     endif
   endif


### PR DESCRIPTION
Tsuquyomi could not locate the server if the project path contained spaces due to the path name not having been escaped or quoted, this PR fixes this problem (fixes #147).