### PR TITLE
Guard Against getSupportedCodeFixes Failing

### DIFF
--- a/autoload/tsuquyomi/tsClient.vim
+++ b/autoload/tsuquyomi/tsClient.vim
@@ -777,7 +777,12 @@ endfunction
 " This command is available only at tsserver ~v.2.1
 function! tsuquyomi#tsClient#tsGetSupportedCodeFixes()
   let l:result = tsuquyomi#tsClient#sendCommandSyncResponse('getSupportedCodeFixes', {})
-  return tsuquyomi#tsClient#getResponseBodyAsDict(l:result)
+  let l:body = tsuquyomi#tsClient#getResponseBodyAsDict(l:result)
+  if (type(l:body) != v:t_list)
+    return []
+  else
+    return l:body
+  endif
 endfunction
 
 


### PR DESCRIPTION
This is in response to: https://github.com/Quramy/tsuquyomi/issues/230

There may be a better way to fix, this eliminated the error in my case though, even though TSServer was throwing this:
https://github.com/Microsoft/TypeScript/issues/21804