### PR TITLE
Support preview window for completion function

### DIFF
--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -402,6 +402,7 @@ function! tsuquyomi#complete(findstart, base)
           let idx = 0
           for menu in menus
             let items[idx].menu = menu
+            let items[idx].info = menu
             call complete_add(items[idx])
             let idx = idx + 1
           endfor


### PR DESCRIPTION
This pull request will add a support of preview window for completion function.

<img width="769" alt="screen shot 2018-09-21 at 18 43 13" src="https://user-images.githubusercontent.com/4361134/45873879-6d550080-bdce-11e8-8a70-5f1b7c207087.png">


Preview window is useful. Completion menu is removed after chose a candidate, but preview window is not removed. And it has larger then menu, so it can more complex type information.

User can disable preview window feature with `completeopt` option.
https://github.com/vim/vim/blob/933bef779a4da4180f9212039363236ff68a33bc/runtime/doc/options.txt#L1966-L1969

You can find a documentation for this patch with `:help complete-items`.
https://github.com/vim/vim/blob/933bef779a4da4180f9212039363236ff68a33bc/runtime/doc/insert.txt#L1096-L1097


Maybe it solves https://github.com/Quramy/tsuquyomi/issues/38, but I'm not sure.


@Quramy What do you think this change?