### PR TITLE
Use setfiletype in ftdetect

### DIFF
--- a/ftdetect/typescript.vim
+++ b/ftdetect/typescript.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.ts,*.tsx set filetype=typescript
+autocmd BufNewFile,BufRead *.ts,*.tsx setfiletype typescript


### PR DESCRIPTION
This change saves the user filetype configuration, especially the jsx(tsx) for which some plugins require composite filetype definition ('typescript.tsx'), like [peitalin/vim-jsx-typescript](https://github.com/peitalin/vim-jsx-typescript).