### PR TITLE
Introduce TsuAsyncGeterr for prevent blocking Vim's UI

### DIFF
--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -596,7 +596,7 @@ function! tsuquyomi#emitChange()
   call tsuquyomi#tsClient#tsAsyncChange(l:file, 1, 1, len(l:input), 1, l:input)
 endfunction
 
-function! tsuquyomi#createAsyncFixlist()
+function! tsuquyomi#asyncCreateFixlist()
   if len(s:checkOpenAndMessage([expand('%:p')])[1])
     return []
   endif

--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -625,7 +625,6 @@ function! tsuquyomi#asyncCreateFixlist()
   if len(s:checkOpenAndMessage([expand('%:p')])[1])
     return []
   endif
-  call s:flush()
   " `tsuquyomi#getSupportedCodeFixes()` is too slow and block Vim's ui.
   " call tsuquyomi#getSupportedCodeFixes()
 

--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -567,7 +567,7 @@ endfunction
 " #### Geterr {{{
 
 function! tsuquyomi#asyncGeterr()
-  let g:tsuquyomi_is_available == 1
+  if g:tsuquyomi_is_available == 1
     call tsuquyomi#registerNotify(function('s:setqflist'), 'diagnostics')
     call tsuquyomi#asyncCreateFixlist()
   endif

--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -567,8 +567,10 @@ endfunction
 " #### Geterr {{{
 
 function! tsuquyomi#asyncGeterr()
-  call tsuquyomi#registerNotify(function('s:setqflist'))
-  call tsuquyomi#asyncCreateFixlist()
+  let g:tsuquyomi_is_available == 1
+    call tsuquyomi#registerNotify(function('s:setqflist'), 'diagnostics')
+    call tsuquyomi#asyncCreateFixlist()
+  endif
 endfunction
 
 function! tsuquyomi#parseDiagnosticEvent(event, supportedCodes)
@@ -603,8 +605,8 @@ function! tsuquyomi#parseDiagnosticEvent(event, supportedCodes)
   return quickfix_list
 endfunction
 
-function! tsuquyomi#registerNotify(callback)
-  call tsuquyomi#tsClient#registerNotify(a:callback)
+function! tsuquyomi#registerNotify(callback, eventName)
+  call tsuquyomi#tsClient#registerNotify(a:callback, a:eventName)
 endfunction
 
 function! tsuquyomi#emitChange()

--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -94,6 +94,16 @@ function! s:writeToPreview(content)
   setlocal nomodifiable readonly
   silent wincmd p
 endfunction
+
+function! s:setqflist(quickfix_list) abort
+  call setqflist(a:quickfix_list, 'r')
+  if len(a:quickfix_list) > 0
+    cwindow
+  else
+    cclose
+  endif
+endfunction
+
 " ### Utilites }}}
 
 " ### Public functions {{{
@@ -556,6 +566,11 @@ endfunction
 
 " #### Geterr {{{
 
+function! tsuquyomi#asyncGeterr()
+  call tsuquyomi#registerNotify(function('s:setqflist'))
+  call tsuquyomi#asyncCreateFixlist()
+endfunction
+
 function! tsuquyomi#parseDiagnosticEvent(event)
   let quickfix_list = []
   let supportedCodes = tsuquyomi#getSupportedCodeFixes()
@@ -584,6 +599,10 @@ function! tsuquyomi#parseDiagnosticEvent(event)
     endfor
   endif
   return quickfix_list
+endfunction
+
+function! tsuquyomi#registerNotify(callback)
+  call tsuquyomi#tsClient#registerNotify(a:callback)
 endfunction
 
 function! tsuquyomi#emitChange()
@@ -642,12 +661,7 @@ endfunction
 function! tsuquyomi#geterr()
   let quickfix_list = tsuquyomi#createFixlist()
 
-  call setqflist(quickfix_list, 'r')
-  if len(quickfix_list) > 0
-    cwindow
-  else
-    cclose
-  endif
+  call s:setqflist(quickfix_list)
 endfunction
 
 function! tsuquyomi#geterrProject()
@@ -677,12 +691,7 @@ function! tsuquyomi#geterrProject()
   " 3. Make a quick fix list for `setqflist`.
   let quickfix_list = tsuquyomi#createQuickFixListFromEvents(result)
 
-  call setqflist(quickfix_list, 'r')
-  if len(quickfix_list) > 0
-    cwindow
-  else
-    cclose
-  endif
+  call s:setqflist(quickfix_list)
 endfunction
 
 function! tsuquyomi#reloadAndGeterr()

--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -95,7 +95,7 @@ function! s:writeToPreview(content)
   silent wincmd p
 endfunction
 
-function! s:setqflist(quickfix_list) abort
+function! s:setqflist(quickfix_list)
   call setqflist(a:quickfix_list, 'r')
   if len(a:quickfix_list) > 0
     cwindow

--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -609,8 +609,7 @@ endfunction
 
 function! tsuquyomi#emitChange()
   let l:bufnum = bufnr('%')
-  let l:inputs = getbufline(l:bufnum, 1, '$')
-  let l:input = join(l:inputs, "\n") . "\n"
+  let l:input = join(getbufline(l:bufnum, 1, '$'), "\n") . "\n"
   let l:file = expand('%:p')
 
   " file, line, offset, endLine, endOffset, insertString
@@ -618,12 +617,17 @@ function! tsuquyomi#emitChange()
 endfunction
 
 function! tsuquyomi#asyncCreateFixlist()
+  " Works only Vim8(+channel, +job)
+  " We must register callbacks(handler and callback) before execute this.
+  " See `tsuquyomi#config#initBuffer()`
   if len(s:checkOpenAndMessage([expand('%:p')])[1])
     return []
   endif
   call s:flush()
+  " `tsuquyomi#getSupportedCodeFixes()` is too slow and block Vim's ui.
+  " call tsuquyomi#getSupportedCodeFixes()
 
-  " Tell TSServer to change.
+  " Tell TSServer to change for get syntaxDiag and semanticDiag errors.
   call tsuquyomi#emitChange()
 
   let l:files = [expand('%:p')]

--- a/autoload/tsuquyomi.vim
+++ b/autoload/tsuquyomi.vim
@@ -571,7 +571,7 @@ endfunction
 
 " #### Geterr {{{
 
-function! tsuquyomi#asyncGeterr()
+function! tsuquyomi#asyncGeterr(...)
   if g:tsuquyomi_is_available == 1
     call tsuquyomi#registerNotify(function('s:setqflist'), 'diagnostics')
     call tsuquyomi#asyncCreateFixlist()

--- a/autoload/tsuquyomi/config.vim
+++ b/autoload/tsuquyomi/config.vim
@@ -293,6 +293,7 @@ function! tsuquyomi#config#registerInitialCallback()
   call tsuquyomi#tsClient#registerCallback('tsuquyomi#tsClient#readDiagnostics')
 endfunction
 
+let s:async_initialized = 0
 function! tsuquyomi#config#initBuffer(opt)
   if !has_key(a:opt, 'pattern')
     echom '[Tsuquyomi] missing options. "pattern"'
@@ -308,8 +309,9 @@ function! tsuquyomi#config#initBuffer(opt)
     silent! call tsuquyomi#open()
     silent! call tsuquyomi#sendConfigure()
   endif
-  if s:is_vim8 && g:tsuquyomi_use_vimproc == 0
+  if s:is_vim8 && g:tsuquyomi_use_vimproc == 0 && s:async_initialized == 0
     call tsuquyomi#config#registerInitialCallback()
+    let s:async_initialized = 1
   endif
   return 1
 endfunction

--- a/autoload/tsuquyomi/config.vim
+++ b/autoload/tsuquyomi/config.vim
@@ -290,7 +290,7 @@ function! tsuquyomi#config#applyBufLocalFunctions()
 endfunction
 
 function! tsuquyomi#config#registerInitialCallback()
-  call tsuquyomi#tsClient#registerCallback('tsuquyomi#tsClient#readDiagnostics')
+  call tsuquyomi#tsClient#registerCallback('tsuquyomi#tsClient#readDiagnostics', 'diagnostics')
 endfunction
 
 let s:async_initialized = 0

--- a/autoload/tsuquyomi/config.vim
+++ b/autoload/tsuquyomi/config.vim
@@ -212,6 +212,8 @@ function! tsuquyomi#config#createBufLocalCommand()
   command! -buffer TsuQuickFix              :call tsuquyomi#quickFix()
   command! -buffer TsuquyomiSignatureHelp   :call tsuquyomi#signatureHelp()
   command! -buffer TsuSignatureHelp         :call tsuquyomi#signatureHelp()
+  command! -buffer TsuAsyncGeterr           :call tsuquyomi#asyncGeterr()
+  command! -buffer TsuquyomiAsyncGeterr     :call tsuquyomi#asyncGeterr()
 
   " TODO These commands don't work correctly.
   command! -buffer TsuquyomiRenameSymbolS   :call tsuquyomi#renameSymbolWithStrings()

--- a/autoload/tsuquyomi/config.vim
+++ b/autoload/tsuquyomi/config.vim
@@ -287,6 +287,10 @@ function! tsuquyomi#config#applyBufLocalFunctions()
   endif
 endfunction
 
+function! tsuquyomi#config#registerInitialCallback()
+  call tsuquyomi#tsClient#registerCallback('tsuquyomi#tsClient#readDiagnostics')
+endfunction
+
 function! tsuquyomi#config#initBuffer(opt)
   if !has_key(a:opt, 'pattern')
     echom '[Tsuquyomi] missing options. "pattern"'
@@ -301,6 +305,9 @@ function! tsuquyomi#config#initBuffer(opt)
   if g:tsuquyomi_auto_open
     silent! call tsuquyomi#open()
     silent! call tsuquyomi#sendConfigure()
+  endif
+  if s:is_vim8 && g:tsuquyomi_use_vimproc == 0
+    call tsuquyomi#config#registerInitialCallback()
   endif
   return 1
 endfunction

--- a/autoload/tsuquyomi/tsClient.vim
+++ b/autoload/tsuquyomi/tsClient.vim
@@ -172,14 +172,13 @@ endfunction
 "Read diagnostics and add to QuickList.
 "
 " PARAM: {dict} response
-function! tsuquyomi#tsClient#readDiagnostics(response)
-  let l:item = json_decode(a:response)
-  if has_key(l:item, 'type') && l:item.type ==# 'event'
-    \ && (l:item.event ==# 'syntaxDiag'
-      \ || l:item.event ==# 'semanticDiag'
-      \ || l:item.event ==# 'requestCompleted')
+function! tsuquyomi#tsClient#readDiagnostics(item)
+  if has_key(a:item, 'type') && a:item.type ==# 'event'
+    \ && (a:item.event ==# 'syntaxDiag'
+      \ || a:item.event ==# 'semanticDiag'
+      \ || a:item.event ==# 'requestCompleted')
 
-    if l:item.event == 'requestCompleted'
+    if a:item.event == 'requestCompleted'
       if s:notify_callback != ''
         let Callback = function(s:notify_callback, [s:quickfix_list])
         call Callback()
@@ -187,7 +186,7 @@ function! tsuquyomi#tsClient#readDiagnostics(response)
       endif
     else
       " Cache syntaxDiag and semanticDiag messages until request was completed.
-      let l:qflist = tsuquyomi#parseDiagnosticEvent(l:item, [])
+      let l:qflist = tsuquyomi#parseDiagnosticEvent(a:item, [])
       let s:quickfix_list += l:qflist
     endif
   endif
@@ -218,9 +217,10 @@ function! tsuquyomi#tsClient#handleMessage(ch, msg)
       return
     endif
   endfor
+  let item = json_decode(l:res_item)
   for callback in s:callback_list
     " Run registerd commands
-    let Callback = function(callback, [l:res_item])
+    let Callback = function(callback, [l:item])
     call Callback()
   endfor
 endfunction

--- a/autoload/tsuquyomi/tsClient.vim
+++ b/autoload/tsuquyomi/tsClient.vim
@@ -29,16 +29,15 @@ endif
 
 let s:request_seq = 0
 
-let s:ignore_respons_conditions = []
+let s:ignore_response_conditions = []
 " ignore events configFileDiag triggered by reload event. See also #99
-call add(s:ignore_respons_conditions, '"type":"event","event":"configFileDiag"')
-call add(s:ignore_respons_conditions, '"type":"event","event":"requestCompleted"')
-call add(s:ignore_respons_conditions, '"type":"event","event":"telemetry"')
-call add(s:ignore_respons_conditions, '"type":"event","event":"projectsUpdatedInBackground"')
-call add(s:ignore_respons_conditions, '"type":"event","event":"typingsInstallerPid"')
-call add(s:ignore_respons_conditions, 'npm notice created a lockfile')
+call add(s:ignore_response_conditions, '"type":"event","event":"configFileDiag"')
+call add(s:ignore_response_conditions, '"type":"event","event":"telemetry"')
+call add(s:ignore_response_conditions, '"type":"event","event":"projectsUpdatedInBackground"')
+call add(s:ignore_response_conditions, '"type":"event","event":"typingsInstallerPid"')
+call add(s:ignore_response_conditions, 'npm notice created a lockfile')
 
-" Async callbacks
+" ### Async variables
 let s:callback_list = []
 let s:notify_callback = ''
 let s:quickfix_list = []
@@ -212,7 +211,7 @@ function! tsuquyomi#tsClient#handleMessage(ch, msg)
   endif
   " Ignore messages.
   let l:to_be_ignored = 0
-  for ignore_reg in s:ignore_respons_conditions
+  for ignore_reg in s:ignore_response_conditions
     let l:to_be_ignored = l:to_be_ignored || (l:res_item =~ ignore_reg)
     if l:to_be_ignored
       return
@@ -287,7 +286,7 @@ function! tsuquyomi#tsClient#sendRequest(line, delay, retry_count, response_leng
       let l:res_list = split(l:tmp2, '\n\+')
       for res_item in l:res_list
         let l:to_be_ignored = 0
-        for ignore_reg in s:ignore_respons_conditions
+        for ignore_reg in s:ignore_response_conditions + ['"type":"event","event":"requestCompleted"']
           let l:to_be_ignored = l:to_be_ignored || (res_item =~ ignore_reg)
           if l:to_be_ignored
             break

--- a/autoload/tsuquyomi/tsClient.vim
+++ b/autoload/tsuquyomi/tsClient.vim
@@ -232,7 +232,7 @@ function! tsuquyomi#tsClient#handleMessage(ch, msg)
 endfunction
 
 function! tsuquyomi#tsClient#clearCallbacks()
-  let s:callback_list = {}
+  let s:callbacks = {}
 endfunction
 
 function! tsuquyomi#tsClient#registerCallback(callback, eventName)

--- a/autoload/tsuquyomi/tsClient.vim
+++ b/autoload/tsuquyomi/tsClient.vim
@@ -163,7 +163,7 @@ function! tsuquyomi#tsClient#statusTss()
       return job_info(s:tsq['job']).status
     endif
   catch
-    return 'dead' 
+    return 'dead'
   endtry
 endfunction
 
@@ -439,7 +439,7 @@ endfunction
 " Param: {int} offset The col number of starting point of range to change.
 " Param: {int} endLine The line number of end point of range to change.
 " Param: {int} endOffset The col number of end point of range to change.
-" Param: {string} insertString String after replacing 
+" Param: {string} insertString String after replacing
 " This command does not return any response.
 function! tsuquyomi#tsClient#tsChange(file, line, offset, endLine, endOffset, insertString)
   let l:args = {'file': a:file, 'line': a:line, 'offset': a:offset, 'endLine': a:endLine, 'endOffset': a:endOffset, 'insertString': a:insertString}
@@ -523,7 +523,7 @@ endfunction
 " PARAM: {int} line The line number of location to complete.
 " PARAM: {int} offset The col number of location to complete.
 " RETURNS: {list<dict>} A list of dictionaries of definition location.
-"   e.g. : 
+"   e.g. :
 "     [{'file': 'hogehoge.ts', 'start': {'line': 3, 'offset': 2}, 'end': {'line': 3, 'offset': 10}}]
 function! tsuquyomi#tsClient#tsDefinition(file, line, offset)
   let l:args = {'file': a:file, 'line': a:line, 'offset': a:offset}
@@ -621,7 +621,7 @@ endfunction
 " PARAM: {string} file File name.
 " PARAM: {int} line The line number of the symbol's position.
 " PARAM: {int} offset The col number of the symbol's position.
-" RETURNS:  {dict}  
+" RETURNS:  {dict}
 "   e.g. :
 "     {
 "       'kind': 'method',
@@ -647,11 +647,11 @@ endfunction
 "       'symbolDisplayString': 'SomeModule.SomeClass',
 "       'refs': [
 "         {
-"           'file': 'SomeClass.ts', 'isWriteAccess': 1, 
+"           'file': 'SomeClass.ts', 'isWriteAccess': 1,
 "           'start': {'line': 3', 'offset': 2}, 'end': {'line': 3, 'offset': 20},
 "           'lineText': 'export class SomeClass {'
 "         }, {
-"           'file': 'OtherClass.ts', 'isWriteAccess': 0, 
+"           'file': 'OtherClass.ts', 'isWriteAccess': 0,
 "           'start': {'line': 5', 'offset': 2}, 'end': {'line': 5, 'offset': 20},
 "           'lineText': 'export class OtherClass extends SomeClass{'
 "         }
@@ -665,9 +665,9 @@ endfunction
 
 " Reload an opend file.
 " It can be used for telling change of buffer to TSServer.
-" PARAM: {string} file File name 
+" PARAM: {string} file File name
 " PARAM: {string} tmpfile
-" RETURNS: {0|1} 
+" RETURNS: {0|1}
 function! tsuquyomi#tsClient#tsReload(file, tmpfile)
   let l:arg = {'file': a:file, 'tmpfile': a:tmpfile}
   " With ts > 2.6 and ts <=1.9, tsserver emit 2 responses by reload request.
@@ -711,7 +711,7 @@ endfunction
 "         },
 "       },
 "       'locs': [{
-"         'file': 'hoge.ts'', 
+"         'file': 'hoge.ts'',
 "         'locs': [
 "           {'start':{'line': 3, 'offset': 4}, 'end':{'line': 3, 'offset': 12}},
 "           ...
@@ -766,7 +766,7 @@ endfunction
 " PARAM: {string} file File name.
 " PARAM: {int} line The line number of the symbol's position.
 " PARAM: {int} offset The col number of the symbol's position.
-" RETURNS:  {dict}  
+" RETURNS:  {dict}
 "   e.g. :
 "     {
 "       'selectedItemIndex': 0,
@@ -825,7 +825,7 @@ endfunction
 " PARAM: {int} line The line number of location to complete.
 " PARAM: {int} offset The col number of location to complete.
 " RETURNS: {list<dict>} A list of dictionaries of type definition location.
-"   e.g. : 
+"   e.g. :
 "     [{'file': 'hogehoge.ts', 'start': {'line': 3, 'offset': 2}, 'end': {'line': 3, 'offset': 10}}]
 function! tsuquyomi#tsClient#tsTypeDefinition(file, line, offset)
   let l:args = {'file': a:file, 'line': a:line, 'offset': a:offset}

--- a/autoload/tsuquyomi/tsClient.vim
+++ b/autoload/tsuquyomi/tsClient.vim
@@ -229,12 +229,6 @@ function! tsuquyomi#tsClient#handleMessage(ch, msg)
     let Callback = function(s:callbacks[l:eventName], [l:item])
     call Callback()
   endif
-
-  " for callback in s:callback_list
-  "   " Run registerd commands
-  "   let Callback = function(callback, [l:item])
-  "   call Callback()
-  " endfor
 endfunction
 
 function! tsuquyomi#tsClient#clearCallbacks()

--- a/doc/tsuquyomi.jax
+++ b/doc/tsuquyomi.jax
@@ -217,6 +217,12 @@ Prompt:
 		表示します.
 		このコマンドにはTypeScript@v1.6.0以上が必要です.
 
+						*:TsuquyomiAsyncGeterr*
+						*:TsuAsyncGeterr*
+:TsuquyomiAsyncGeterr
+		カレントバッファのコンパイルエラー情報を非同期で
+		QuickFixウィンドウへ表示します.
+
 						*:TsuquyomiSeaarch*
 						*:TsuSearch*
 :TsuquyomiSearch {keyword}
@@ -500,6 +506,14 @@ EXAMPLES					*tsuquyomi-examples*
 	補完時, ポップアップメニューを表示しない.
 >
 	autocmd FileType typescript setlocal completeopt-=menu
+<
+
+						*tsuquyomi-examples-async*
+Vim8 の Job / Channel を利用し非同期でカレントバッファのコンパイルエラー情報を
+QuickFixウィンドウへ表示します.
+
+>
+	autocmd InsertLeave,BufWritePost *.ts,*.tsx call tsuquyomi#asyncGeterr()
 <
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -207,6 +207,12 @@ COMMANDS					*tsuquyomi-commands*
 :TsuquyomiGeterr
 		Show compilation errors of current buffer in QuickFix window.
 
+						*:TsuquyomiAsynGeterr*
+						*:TsuAsyncGeterr*
+:TsuquyomiAsyncGeterr
+		Show compilation errors of current buffer in QuickFix window
+		asynchronous.
+
 						*:TsuquyomiGeterrProject*
 						*:TsuGeterrProject*
 :TsuquyomiGeterrProject
@@ -495,6 +501,11 @@ You can configure tsuquyomi completion, using 'completeopt' .
 	When completion, don't show the popup menu of completions.
 >
 	autocmd FileType typescript setlocal completeopt-=menu
+<
+Show compile errors to QuickFix window asynchronous by Vim8's Job/Channel
+feature.
+>
+	autocmd InsertLeave,BufWritePost *.ts,*.tsx call tsuquyomi#asyncGeterr()
 <
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:


### PR DESCRIPTION
Closes #241 #250  #274 

Currently `tsuGeterr` sometimes slow.
- Responses of TSServer is slow
- `tsuquyomi#tsClient#sendRequest` wait TSServer's responses synchronous

I introduce async feature to tsuquyomi and this change will prevent blocking Vim.

- Add TsuAsyncGeterr

### Before
![20181222025514](https://user-images.githubusercontent.com/56591/51098373-2ec7d380-180d-11e9-817e-5ee56d8218ad.gif)

Start Vim and run `:TsuGeterr` block Vim's UI.

### After
![20181222030146](https://user-images.githubusercontent.com/56591/51098401-70587e80-180d-11e9-80b7-3e397a2439db.gif)

Start Vim and run `:TsuAsyncGeterr` does not block Vim's UI.
After run `:TsuAsyncGeterr`, you can operate Vim(Not blocking).

### How to work

Set `let g:tsuquyomi_use_vimproc = 0` to your `.vimrc`.
This PR use Vim8's job and channel feature.

Execute `:tsuAsyncGeterr`

or add followings to your `.vimrc`.
```
autocmd InsertLeave,TextChanged,BufWritePost *.ts,*.tsx call tsuquyomi#asyncGeterr()
```

### TODO
After this PR would accepted, I'll add `event queue` mechanism to debounce `send change event to TSServer`. 
`TextChanged` would send buffer to TSServer when text are chaned.
We don't need to send buffer each time.

Also I try to add test, but in my local, did not ran test well.
It would be glad to add `tsAsyncGeterr.spec.vim`.