### PR TITLE
Display importable modules when there are several candidates

### DIFF
--- a/autoload/tsuquyomi/es6import.vim
+++ b/autoload/tsuquyomi/es6import.vim
@@ -407,7 +407,7 @@ endfunction
 
 function! tsuquyomi#es6import#selectModule()
   echohl String
-  let l:selected_module = input('[Tsuquyomi] You can import from 2 or more modules. Select one : ', '', 'custom,tsuquyomi#es6import#moduleComplete')
+  let l:selected_module = input("[Tsuquyomi] You can import from 2 or more modules.\n" . join(s:importable_module_list, "\n") . "\nSelect one: ", '', 'custom,tsuquyomi#es6import#moduleComplete')
   echohl none
   echo ' '
   if len(filter(copy(s:importable_module_list), 'v:val==#l:selected_module'))


### PR DESCRIPTION
Problem
===

`TsuImport` does not display candidates, so I cannot know the candidates without completion.


I didn't know the existence of the completion, so I've given up using the feature with multiple candidates until I've known the completion by reading Tsuquyomi source code.
I guess other people also give up it. And completion candidates are not displayed if `wildmenu` setting is disabled.  So I think displaying the candidates is better.



Screenshot
===


When `./a` and `./a2` are available.


before

![190207205949](https://user-images.githubusercontent.com/4361134/52410325-5adc2900-2b1b-11e9-8901-05ef9bd5bd49.png)

after

![190207205926](https://user-images.githubusercontent.com/4361134/52410335-5f084680-2b1b-11e9-9341-73d7ef8f7e98.png)
