### PR TITLE
Clarify vimproc requirement for neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Tsuquyomi requires the following:
 
 + [Vim](http://www.vim.org/) (vim7.4 or later)
 + [Node.js](https://nodejs.org/) & [TypeScript](https://github.com/Microsoft/TypeScript)
-+ [Shougo/vimproc.vim](https://github.com/Shougo/vimproc.vim) (Not required if you use vim8 or later)
++ [Shougo/vimproc.vim](https://github.com/Shougo/vimproc.vim) (Required for vim < 8 and for neovim)
 
 ### Install TypeScript
 


### PR DESCRIPTION
As neovim has built in async support it isn't completely clear that it
should be required but it is so we try to make it clearer.

I'm not completely happy with the phrasing of 'vim < 8' maybe there is a
better way to do it.

Attempts to address: #295