### PR TITLE
Allow specifying tsserver NODE_ENV --max-old-space-size via config variable

### DIFF
--- a/autoload/tsuquyomi/tsClient.vim
+++ b/autoload/tsuquyomi/tsClient.vim
@@ -98,8 +98,15 @@ function! s:startTssVim8()
     return 'existing'
   endif
   let l:cmd = substitute(tsuquyomi#config#tsscmd(), '\\', '\\\\', 'g').' '.tsuquyomi#config#tssargs()
+  let l:env = {}
+
+  if exists('g:tsuquyomi_tsserver_max_old_space_size')
+    let l:env['NODE_OPTIONS'] = '--max-old-space-size='.g:tsuquyomi_tsserver_max_old_space_size
+  endif
+
   try
     let s:tsq['job'] = job_start(l:cmd, {
+      \ 'env': l:env,
       \ 'out_cb': {ch, msg -> tsuquyomi#tsClient#handleMessage(ch, msg)},
       \ })
 

--- a/doc/tsuquyomi.jax
+++ b/doc/tsuquyomi.jax
@@ -298,6 +298,15 @@ g:tsuquyomi_tsserver_path	(デフォルト値 `''`)
 g:tsuquyomi_nodejs_path		(デフォルト値 "node")
 		Node.js の実行パス.
 
+				*g:tsuquyomi_tsserver_max_old_space_size*
+g:tsuquyomi_tsserver_max_old_space_size		(デフォルト `''`)
+		`tsserver.js`を実行するNode.jsプロセスの最大オールドスペース
+		サイズを指定します。この変数が設定されている場合、Tsuquyomiは
+		その値を`NODE_OPTIONS`環境変数の`--max-old-space-size`引数とし
+		て使用します。例えば、
+>
+		let g:tsuquyomi_tsserver_max_old_space_size = '4096'
+<
 						*g:tsuquyomi_definition_split*
 g:tsuquyomi_definition_split	(デフォルト値 0)
 		|:TsuquyomiDefinition| にて別ファイル定義への遷移時,

--- a/doc/tsuquyomi.txt
+++ b/doc/tsuquyomi.txt
@@ -294,6 +294,15 @@ g:tsuquyomi_tsserver_path	(default `''`)
 g:tsuquyomi_nodejs_path		(default "node")
 		A path to Node.js.
 
+				*g:tsuquyomi_tsserver_max_old_space_size*
+g:tsuquyomi_tsserver_max_old_space_size		(default `''`)
+		Specifies the maximum old space size for the Node.js process
+		running `tsserver.js`. If this variable is set, Tsuquyomi
+		will use its value as the argument for `--max-old-space-size`
+		in the `NODE_OPTIONS` environment variable. For example,
+>
+		let g:tsuquyomi_tsserver_max_old_space_size = '4096'
+<
 						*g:tsuquyomi_definition_split*
 g:tsuquyomi_definition_split	(default 0)
 		A way to open a target file when navigating with

--- a/plugin/tsuquyomi.vim
+++ b/plugin/tsuquyomi.vim
@@ -34,6 +34,8 @@ let g:tsuquyomi_tsserver_debug =
       \ get(g:, 'tsuquyomi_tsserver_debug', 0)
 let g:tsuquyomi_nodejs_path = 
       \ get(g:, 'tsuquyomi_nodejs_path', 'node')
+let g:tsuquyomi_tsserver_max_old_space_size =
+      \ get(g:, 'tsuquyomi_tsserver_max_old_space_size', '')
 let g:tsuquyomi_waittime_after_open = 
       \ get(g:, 'tsuquyomi_waittime_after_open', str2float("0.01"))
 let g:tsuquyomi_completion_chunk_size = 


### PR DESCRIPTION
Hey there, longtime tsuquyomi user here! Thank you for such a wonderful plugin 🙏 When working on larger projects, I noticed that using various commands (e.g. jump to definition, show hint) would make vim hang for a long time, with tsserver evidently struggling. With some hacking, I realized that bumping the `--max-old-space-size` of the node process running tsserver seemed to help with this.

This PR exposes config variable `tsuquyomi_tsserver_max_old_space_size` to allow the user to easily configure the heap size for the node process running tsserver.

There's no open issues for this or anything, but it's helped save me some time so figured I'd open a PR to see if there's any interest in getting this in mainline. Thanks!

** the Japanese in the docs was translated by GPT-4o so please forgive any mistakes